### PR TITLE
Assign current member role during registration

### DIFF
--- a/app/HMS/Repositories/RoleRepository.php
+++ b/app/HMS/Repositories/RoleRepository.php
@@ -33,12 +33,4 @@ class RoleRepository extends EntityRepository
     {
         return parent::findOneBy(['name' => $roleName]);
     }
-
-    /**
-     * @return Role|object
-     */
-    public function getMember()
-    {
-        return parent::findOneBy(['name' => 'member']);
-    }
 }

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Auth;
 
 use HMS\Auth\IdentityManager;
+use HMS\Entities\Role;
 use HMS\Entities\User;
 
 use HMS\Repositories\RoleRepository;
@@ -80,7 +81,7 @@ class RegisterController extends Controller
             $data['email']
         );
 
-        $user->getRoles()->add($this->roleRepository->getMember());
+        $user->getRoles()->add($this->roleRepository->findByName(Role::MEMBER_CURRENT));
 
         // TODO: maybe consolidate these into a single call via a service?
         $this->userRepository->create($user);


### PR DESCRIPTION
This a quick fix to allow the registration process to continue working as it was before. We've changed around the migrations a bit and the 'member' role I was assigning no longer exists which broke the registration process. I know this will change in the future but this gets the application working again in the meantime.