### PR TITLE
Enable colouring of links using the Foundation colour palette.

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -72,3 +72,13 @@ ul.nomarkers {
   @extend .medium-10;
   @extend .medium-offset-2;
 }
+
+// Link colouring
+// --------------
+
+// create an a-specific class for each colour in the palette
+@each $name, $color in $foundation-palette {
+  a.#{$name} {
+    color: $color;
+  }
+}


### PR DESCRIPTION
Auto-generates a class for each of the Foundation colour palette colours which works on <a> tags, in the same way that there are such classes for buttons, callouts etc.

Closes #60 