### PR TITLE
Fix JavaScript build and bundling and make Foundation JS plugins work.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,8 @@ require('laravel-elixir-vue-2');
  */
 
 elixir(mix => {
+
+    // compile SCSS
     var options = {
         includePaths: [
             'node_modules/foundation-sites/scss',
@@ -23,15 +25,18 @@ elixir(mix => {
 
     mix.sass('app.scss', null, null, options);
 
+    // version CSS file
     mix.version('css/app.css');
 
+    // bundle up jQuery and Foundation JavaScript to app-base.js
     var jQuery = '../../../node_modules/jquery/dist/jquery.js';
-    var foundationJsFolder = '../../../node_modules/foundation-sites/js/';
+    var foundation = '../../../node_modules/foundation-sites/dist/foundation.js';
 
     mix.scripts([
-        jQuery,
-        foundationJsFolder + 'foundation.core.js'
-    ]);
+      jQuery,
+      foundation
+    ], 'public/js/app-base.js').version('js/app-base.js');
 
-    mix.webpack('app.js');
+    // compile application global JS
+    mix.webpack('app.js').version('js/app.js');
 });

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -1,0 +1,7 @@
+// This file is for global JavaScript which is to be present on every page.
+// It is compiled by Webpack, so can freely contain ES2015 code.
+
+// Initialise Foundation plugins
+$(() => {
+  $(document).foundation();
+});

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -128,6 +128,9 @@
 
 
   <!-- Scripts -->
-  <script src="/js/app.js"></script>
+  <script src="{{ elixir('js/app-base.js')}}"></script>
+  <script src="{{ elixir('js/app.js') }}"></script>
+
+  @stack('scripts')
 </body>
 </html>


### PR DESCRIPTION
jQuery and Foundation get combined into one JS file.
app.js (site global JS) gets compiled with Webpack into another.
app.js also now contains the initialisation code for Foundation plugins.

All these files are included in the default layout.