### PR TITLE
Vagrant: move keytab inside the vagrant box

### DIFF
--- a/dev/vagrant-config/laravel/.env
+++ b/dev/vagrant-config/laravel/.env
@@ -38,7 +38,7 @@ PASSWORDSTORE=Kerberos
 PASSWORDSTORE_FILE=users.json
 
 KRB_USERNAME=hms/web 
-KRB_KEYTAB=/vagrant/storage/app/hms.keytab
+KRB_KEYTAB=/home/vagrant/hms.keytab
 KRB_REALM=NOTTINGTEST.ORG.UK
 KRB_DEBUG=false
 

--- a/dev/vagrant-config/scripts/kerberos.sh
+++ b/dev/vagrant-config/scripts/kerberos.sh
@@ -33,9 +33,9 @@ kadmin.local -q "addprinc -pw vagrant vagrant/admin"
 kadmin.local -q "addprinc -pw vagrant vagrant"
 kadmin.local -q "addprinc -randkey hms/web"
 
-rm /vagrant/storage/app/hms.keytab
-kadmin.local -q "ktadd -k /vagrant/storage/app/hms.keytab hms/web"
-chmod a+r /vagrant/storage/app/hms.keytab
+rm /home/vagrant/hms.keytab
+kadmin.local -q "ktadd -k /home/vagrant/hms.keytab hms/web"
+chmod a+r /home/vagrant/hms.keytab
 
 
 # pecl install krb5 - this (still 2016) doesn't have kadm support.


### PR DESCRIPTION
this little tweak allows me and others vagrant up the same clone across different machines with out breaking the kerberos logins when the key tab is replaced