### PR TITLE
Correct Role User many to many mapping

### DIFF
--- a/app/HMS/Mappings/HMS.Entities.Role.dcm.yml
+++ b/app/HMS/Mappings/HMS.Entities.Role.dcm.yml
@@ -53,15 +53,4 @@ HMS\Entities\Role:
             onDelete: CASCADE
     users:
       targetEntity: User
-      joinTable:
-        name: role_user
-        joinColumns:
-          role_id:
-            referencedColumnName: id
-            onDelete: CASCADE
-        inverseJoinColumns:
-          user_id:
-            referencedColumnName: id
-            onDelete: CASCADE
-
-
+      mappedBy: roles


### PR DESCRIPTION
Inverse mapping only needs to define the `mappedBy` pram
We also don’t need the cascade delete’s as both User and Role are soft deletable the many to many does magic they won’t show

This was introduced by cb60601