### PR TITLE
Role update

### DIFF
--- a/app/Console/Commands/Permissions/DefaultsCommand.php
+++ b/app/Console/Commands/Permissions/DefaultsCommand.php
@@ -83,6 +83,15 @@ class DefaultsCommand extends BaseCommand
     {
         foreach ($this->roles as $roleName => $role) {
             $roleEntity = new Role($roleName, $role['name'], $role['description']);
+            if (isset($role['email'])) {
+                $roleEntity->setEmail($role['email']);
+            }
+            if (isset($role['slackChannel'])) {
+                $roleEntity->setSlackChannel($role['slackChannel']);
+            }
+            if (isset($role['retained'])) {
+                $roleEntity->setRetained($role['retained']);
+            }
             if (count($role['permissions']) == 1 && $role['permissions'][0] == '*') {
                 foreach ($this->permissions as $permission) {
                     $roleEntity->addPermission($permission);

--- a/app/Events/MembershipInterestRegistered.php
+++ b/app/Events/MembershipInterestRegistered.php
@@ -3,14 +3,11 @@
 namespace App\Events;
 
 use HMS\Entities\Invite;
-use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Broadcasting\InteractsWithSockets;
 
 class MembershipInterestRegistered
 {
-    use InteractsWithSockets, SerializesModels;
+    use SerializesModels;
 
     /**
      * @var Invite
@@ -25,15 +22,5 @@ class MembershipInterestRegistered
     public function __construct(Invite $invite)
     {
         $this->invite = $invite;
-    }
-
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return Channel|array
-     */
-    public function broadcastOn()
-    {
-        return new PrivateChannel('channel-name');
     }
 }

--- a/app/Events/Roles/RoleCreated.php
+++ b/app/Events/Roles/RoleCreated.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Events\Roles;
+
+use HMS\Entities\Role;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class RoleCreated
+{
+    use InteractsWithSockets, SerializesModels;
+
+    /**
+     * @var HMS\Entities\Role
+     */
+    public $role;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param HMS\Entities\Role $role
+     */
+    public function __construct(Role $role)
+    {
+        //
+        $this->role = $role;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/Events/Roles/RoleCreated.php
+++ b/app/Events/Roles/RoleCreated.php
@@ -3,14 +3,11 @@
 namespace App\Events\Roles;
 
 use HMS\Entities\Role;
-use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Broadcasting\InteractsWithSockets;
 
 class RoleCreated
 {
-    use InteractsWithSockets, SerializesModels;
+    use SerializesModels;
 
     /**
      * @var HMS\Entities\Role
@@ -26,15 +23,5 @@ class RoleCreated
     {
         //
         $this->role = $role;
-    }
-
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return Channel|array
-     */
-    public function broadcastOn()
-    {
-        return new PrivateChannel('channel-name');
     }
 }

--- a/app/Events/Roles/RoleCreated.php
+++ b/app/Events/Roles/RoleCreated.php
@@ -6,9 +6,7 @@ use HMS\Entities\Role;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 class RoleCreated
 {

--- a/app/Events/Roles/UserAddedToRole.php
+++ b/app/Events/Roles/UserAddedToRole.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Events\Roles;
+
+use HMS\Entities\Role;
+use HMS\Entities\User;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class UserAddedToRole
+{
+    use InteractsWithSockets, SerializesModels;
+
+    /**
+     * @var HMS\Entities\User
+     */
+    public $user;
+
+    /**
+     * @var HMS\Entities\Role
+     */
+    public $role;
+
+    /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(User $user, Role $role)
+    {
+        //
+        $this->user = $user;
+        $this->role = $role;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/Events/Roles/UserAddedToRole.php
+++ b/app/Events/Roles/UserAddedToRole.php
@@ -4,14 +4,11 @@ namespace App\Events\Roles;
 
 use HMS\Entities\Role;
 use HMS\Entities\User;
-use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Broadcasting\InteractsWithSockets;
 
 class UserAddedToRole
 {
-    use InteractsWithSockets, SerializesModels;
+    use SerializesModels;
 
     /**
      * @var HMS\Entities\User
@@ -33,15 +30,5 @@ class UserAddedToRole
         //
         $this->user = $user;
         $this->role = $role;
-    }
-
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return Channel|array
-     */
-    public function broadcastOn()
-    {
-        return new PrivateChannel('channel-name');
     }
 }

--- a/app/Events/Roles/UserAddedToRole.php
+++ b/app/Events/Roles/UserAddedToRole.php
@@ -7,9 +7,7 @@ use HMS\Entities\User;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 class UserAddedToRole
 {

--- a/app/Events/Roles/UserRemovedFromRole.php
+++ b/app/Events/Roles/UserRemovedFromRole.php
@@ -7,9 +7,7 @@ use HMS\Entities\User;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Broadcasting\PresenceChannel;
 use Illuminate\Broadcasting\InteractsWithSockets;
-use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 class UserRemovedFromRole
 {
@@ -25,7 +23,7 @@ class UserRemovedFromRole
      */
     public $role;
 
-   /**
+    /**
      * Create a new event instance.
      *
      * @return void

--- a/app/Events/Roles/UserRemovedFromRole.php
+++ b/app/Events/Roles/UserRemovedFromRole.php
@@ -4,14 +4,11 @@ namespace App\Events\Roles;
 
 use HMS\Entities\Role;
 use HMS\Entities\User;
-use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Broadcasting\PrivateChannel;
-use Illuminate\Broadcasting\InteractsWithSockets;
 
 class UserRemovedFromRole
 {
-    use InteractsWithSockets, SerializesModels;
+    use SerializesModels;
 
     /**
      * @var HMS\Entities\User
@@ -33,15 +30,5 @@ class UserRemovedFromRole
         //
         $this->user = $user;
         $this->role = $role;
-    }
-
-    /**
-     * Get the channels the event should broadcast on.
-     *
-     * @return Channel|array
-     */
-    public function broadcastOn()
-    {
-        return new PrivateChannel('channel-name');
     }
 }

--- a/app/Events/Roles/UserRemovedFromRole.php
+++ b/app/Events/Roles/UserRemovedFromRole.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Events\Roles;
+
+use HMS\Entities\Role;
+use HMS\Entities\User;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Broadcasting\PresenceChannel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+
+class UserRemovedFromRole
+{
+    use InteractsWithSockets, SerializesModels;
+
+    /**
+     * @var HMS\Entities\User
+     */
+    public $user;
+
+    /**
+     * @var HMS\Entities\Role
+     */
+    public $role;
+
+   /**
+     * Create a new event instance.
+     *
+     * @return void
+     */
+    public function __construct(User $user, Role $role)
+    {
+        //
+        $this->user = $user;
+        $this->role = $role;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/app/HMS/Entities/Role.php
+++ b/app/HMS/Entities/Role.php
@@ -4,6 +4,7 @@ namespace HMS\Entities;
 
 use HMS\Traits\Entities\SoftDeletable;
 use HMS\Traits\Entities\Timestampable;
+use Illuminate\Notifications\Notifiable;
 use LaravelDoctrine\ACL\Contracts\Permission;
 use Doctrine\Common\Collections\ArrayCollection;
 use LaravelDoctrine\ACL\Permissions\HasPermissions;
@@ -11,7 +12,7 @@ use LaravelDoctrine\ACL\Contracts\Role as RoleContract;
 
 class Role implements RoleContract
 {
-    use HasPermissions, SoftDeletable, Timestampable;
+    use HasPermissions, SoftDeletable, Timestampable, Notifiable;
 
     const MEMBER_CURRENT = 'member.current';
     const MEMBER_APPROVAL = 'member.approval';
@@ -52,6 +53,21 @@ class Role implements RoleContract
     protected $users;
 
     /**
+     * @var string Team email address
+     */
+    protected $email;
+
+    /**
+     * @var string Team slack channel
+     */
+    protected $slackChannel;
+
+    /**
+     * @var boolean Should this role be retained by ex members
+     */
+    protected $retained;
+
+    /**
      * Role constructor.
      * @param $name
      * @param $displayName
@@ -63,6 +79,7 @@ class Role implements RoleContract
         $this->displayName = $displayName;
         $this->description = $description;
         $this->permissions = new ArrayCollection();
+        $this->retained = false;
     }
 
     /**
@@ -150,5 +167,91 @@ class Role implements RoleContract
     public function getUsers()
     {
         return $this->users;
+    }
+
+    /**
+     * Gets the value of email.
+     *
+     * @return string Team email address
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * Sets the value of email.
+     *
+     * @param string Team email address $email the email
+     *
+     * @return self
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    /**
+     * Gets the value of slackChannel.
+     *
+     * @return string team slack channel
+     */
+    public function getSlackChannel()
+    {
+        return $this->slackChannel;
+    }
+
+    /**
+     * Sets the value of slackChannel.
+     *
+     * @param string team slack channel $slackChannel the slack channel
+     *
+     * @return self
+     */
+    public function setSlackChannel($slackChannel)
+    {
+        $this->slackChannel = $slackChannel;
+
+        return $this;
+    }
+
+    /**
+     * Gets the value of retained.
+     *
+     * @return boolean Should this role be retained by ex members
+     */
+    public function getRetained()
+    {
+        return $this->retained;
+    }
+
+    /**
+     * Sets the value of retained.
+     *
+     * @param boolean Should this role be retained by ex members $retained the retained
+     *
+     * @return self
+     */
+    public function setRetained($retained)
+    {
+        $this->retained = $retained;
+
+        return $this;
+    }
+
+    /**
+     * Route notifications for the Slack channel.
+     *
+     * @return string
+     */
+    public function routeNotificationForSlack()
+    {
+        if ($this->name = 'team.Trustees') {
+            return Meta::get('trustee_slack_webhook');
+        } else {
+            return Meta::get('team_slack_webhook');
+        }
     }
 }

--- a/app/HMS/Entities/Role.php
+++ b/app/HMS/Entities/Role.php
@@ -63,7 +63,7 @@ class Role implements RoleContract
     protected $slackChannel;
 
     /**
-     * @var boolean Should this role be retained by ex members
+     * @var bool Should this role be retained by ex members
      */
     protected $retained;
 
@@ -220,7 +220,7 @@ class Role implements RoleContract
     /**
      * Gets the value of retained.
      *
-     * @return boolean Should this role be retained by ex members
+     * @return bool Should this role be retained by ex members
      */
     public function getRetained()
     {
@@ -230,7 +230,7 @@ class Role implements RoleContract
     /**
      * Sets the value of retained.
      *
-     * @param boolean Should this role be retained by ex members $retained the retained
+     * @param bool Should this role be retained by ex members $retained the retained
      *
      * @return self
      */

--- a/app/HMS/Mappings/HMS.Entities.Role.dcm.yml
+++ b/app/HMS/Mappings/HMS.Entities.Role.dcm.yml
@@ -25,6 +25,16 @@ HMS\Entities\Role:
       type: string
     description:
       type: text
+    email:
+      type: string
+      nullable: true
+    slackChannel:
+      type: string
+      nullable: true
+    retained:
+      type: boolean
+      options:
+        default: 0 
     deletedAt:
       type: datetime
       nullable: true

--- a/app/HMS/User/Permissions/RoleManager.php
+++ b/app/HMS/User/Permissions/RoleManager.php
@@ -45,6 +45,20 @@ class RoleManager
             $role->setDescription($details['description']);
         }
 
+        if (isset($details['email'])) {
+            $role->setEmail($details['email']);
+        }
+
+        if (isset($details['slackChannel'])) {
+            $role->setSlackChannel($details['slackChannel']);
+        }
+
+        if (isset($details['retained'])) {
+            $role->setRetained(true);
+        } else {
+            $role->setRetained(false);
+        }
+
         if (isset($details['permissions'])) {
             $role->stripPermissions();
             foreach (array_keys($details['permissions']) as $permissionName) {

--- a/app/HMS/User/Permissions/RoleManager.php
+++ b/app/HMS/User/Permissions/RoleManager.php
@@ -3,7 +3,11 @@
 namespace HMS\User\Permissions;
 
 use HMS\Entities\Role;
+use HMS\Entities\User;
 use HMS\Repositories\RoleRepository;
+use HMS\Repositories\UserRepository;
+use App\Events\Roles\UserAddedToRole;
+use App\Events\Roles\UserRemovedFromRole;
 use HMS\Repositories\PermissionRepository;
 
 class RoleManager
@@ -19,14 +23,20 @@ class RoleManager
     private $permissionRepository;
 
     /**
+     * @var UserRepository
+     */
+    protected $userRepository;
+
+    /**
      * Create a new RoleManager instance.
      *
      * @param HMS\Repositories\RoleRepository $roleRepository An instance of a role repository
      */
-    public function __construct(RoleRepository $roleRepository, PermissionRepository $permissionRepository)
+    public function __construct(RoleRepository $roleRepository, PermissionRepository $permissionRepository, UserRepository $userRepository)
     {
         $this->roleRepository = $roleRepository;
         $this->permissionRepository = $permissionRepository;
+        $this->userRepository = $userRepository;
     }
 
     /**
@@ -67,5 +77,42 @@ class RoleManager
         }
 
         $this->roleRepository->save($role);
+    }
+
+    /**
+     * add user to Role and fire of an event
+     * @param User   $user
+     * @param Role   $role
+     */
+    public function addUserToRole(User $user, Role $role)
+    {
+        $user->getRoles()->add($role);
+        $this->userRepository->save($user);
+        event( new UserAddedToRole($user, $role));
+    }
+
+    /**
+     * add user to Role and fire of an event
+     * @param User   $user
+     * @param string $roleName take a role name string rather than a role enitity
+     */
+    public function addUserToRoleByName(User $user, $roleName)
+    {
+        $role = $this->roleRepository->findOneByName($roleName);
+        $user->getRoles()->add($role);
+        $this->userRepository->save($user);
+        event( new UserAddedToRole($user, $role));
+    }
+
+    /**
+     * remove a user from a role and fire of an update event
+     * @param  User   $user
+     * @param  Role   $role
+     */
+    public function removeUserFromRole(User $user, Role $role)
+    {
+        $user->getRoles()->removeElement($role);
+        $this->userRepository->save($user);
+        event( new UserRemovedFromRole($user, $role));
     }
 }

--- a/app/HMS/User/Permissions/RoleManager.php
+++ b/app/HMS/User/Permissions/RoleManager.php
@@ -80,7 +80,7 @@ class RoleManager
     }
 
     /**
-     * add user to Role and fire of an event
+     * add user to Role and fire of an event.
      * @param User   $user
      * @param Role   $role
      */
@@ -88,11 +88,11 @@ class RoleManager
     {
         $user->getRoles()->add($role);
         $this->userRepository->save($user);
-        event( new UserAddedToRole($user, $role));
+        event(new UserAddedToRole($user, $role));
     }
 
     /**
-     * add user to Role and fire of an event
+     * add user to Role and fire of an event.
      * @param User   $user
      * @param string $roleName take a role name string rather than a role enitity
      */
@@ -101,11 +101,11 @@ class RoleManager
         $role = $this->roleRepository->findOneByName($roleName);
         $user->getRoles()->add($role);
         $this->userRepository->save($user);
-        event( new UserAddedToRole($user, $role));
+        event(new UserAddedToRole($user, $role));
     }
 
     /**
-     * remove a user from a role and fire of an update event
+     * remove a user from a role and fire of an update event.
      * @param  User   $user
      * @param  Role   $role
      */
@@ -113,6 +113,6 @@ class RoleManager
     {
         $user->getRoles()->removeElement($role);
         $this->userRepository->save($user);
-        event( new UserRemovedFromRole($user, $role));
+        event(new UserRemovedFromRole($user, $role));
     }
 }

--- a/app/HMS/User/UserManager.php
+++ b/app/HMS/User/UserManager.php
@@ -5,8 +5,8 @@ namespace HMS\User;
 use HMS\Entities\Role;
 use HMS\Entities\User;
 use HMS\Auth\PasswordStore;
-use HMS\Repositories\RoleRepository;
 use HMS\Repositories\UserRepository;
+use HMS\User\Permissions\RoleManager;
 
 class UserManager
 {
@@ -14,10 +14,12 @@ class UserManager
      * @var UserRepository
      */
     private $userRepository;
+
     /**
-     * @var RoleRepository
+     * @var RoleManager
      */
-    private $roleRepository;
+    private $roleManager;
+
     /**
      * @var PasswordStore
      */
@@ -26,14 +28,14 @@ class UserManager
     /**
      * UserManager constructor.
      * @param UserRepository $userRepository
-     * @param RoleRepository $roleRepository
+     * @param RoleManager $roleManager
      * @param PasswordStore $passwordStore
      */
     public function __construct(UserRepository $userRepository,
-        RoleRepository $roleRepository, PasswordStore $passwordStore)
+        RoleManager $roleManager, PasswordStore $passwordStore)
     {
         $this->userRepository = $userRepository;
-        $this->roleRepository = $roleRepository;
+        $this->roleManager = $roleManager;
         $this->passwordStore = $passwordStore;
     }
 
@@ -43,9 +45,7 @@ class UserManager
      */
     public function removeRoleFromUser($user, $role)
     {
-        $user->getRoles()->removeElement($role);
-
-        $this->userRepository->save($user);
+        $this->roleManager->removeUserFromRole($user, $role);
     }
 
     /**
@@ -60,11 +60,11 @@ class UserManager
     {
         $user = new User($firstname, $lastname, $username, $email);
 
-        $user->getRoles()->add($this->roleRepository->findByName(Role::MEMBER_CURRENT));
-
         // TODO: maybe consolidate these into a single call via a service?
         $this->userRepository->save($user);
         $this->passwordStore->add($user->getUsername(), $password);
+
+        $this->roleManager->addUserToRoleByName($user, Role::MEMBER_CURRENT);
 
         return $user;
     }

--- a/config/roles.php
+++ b/config/roles.php
@@ -20,6 +20,7 @@ return [
         'accessCodes.view',
         'meta.view',
         'meta.edit',
+        'membership.approval',
     ],
 
     /*
@@ -76,6 +77,29 @@ return [
             'description'   => 'Full access to all parts of the system',
             'permissions'   =>  [
                 '*',
+            ],
+        ],
+        'team.membership'    => [
+            'name'          => 'Membership Team',
+            'description'   => 'Membership Team',
+            'email'         => 'membership@nottinghack.org.uk',
+            'slackChannel'  => '#membership',
+            'permissions'   => [
+                'profile.view.all',
+                'membership.approval',
+            ],
+        ],
+        'team.trustees'    => [
+            'name'          => 'Trustees',
+            'description'   => 'The Trustees',
+            'email'         => 'trustees@nottinghack.org.uk',
+            'slackChannel'  => '#general',
+            'permissions'   => [
+                'profile.view.all',
+                'profile.edit.all',
+                'meta.view',
+                'meta.edit',
+                'membership.approval',
             ],
         ],
     ],

--- a/database/migrations/Version20170423104651_add_email_slack_retained_to_role.php
+++ b/database/migrations/Version20170423104651_add_email_slack_retained_to_role.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Migrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema as Schema;
+
+class Version20170423104651_add_email_slack_retained_to_role extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE roles ADD email VARCHAR(255) DEFAULT NULL, ADD slack_channel VARCHAR(255) DEFAULT NULL, ADD retained TINYINT(1) DEFAULT \'0\' NOT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE roles DROP email, DROP slack_channel, DROP retained');
+    }
+}

--- a/database/migrations/Version20170423104651_add_email_slack_retained_to_role.php
+++ b/database/migrations/Version20170423104651_add_email_slack_retained_to_role.php
@@ -2,8 +2,8 @@
 
 namespace Database\Migrations;
 
-use Doctrine\DBAL\Migrations\AbstractMigration;
 use Doctrine\DBAL\Schema\Schema as Schema;
+use Doctrine\DBAL\Migrations\AbstractMigration;
 
 class Version20170423104651_add_email_slack_retained_to_role extends AbstractMigration
 {

--- a/resources/views/role/edit.blade.php
+++ b/resources/views/role/edit.blade.php
@@ -33,7 +33,46 @@
         </div>
     </div>
 
+    <div class="row">
+        <label for="email" class="form-label">Email</label>
+        <div class="form-control">
+            <input id="email" type="text" name="email" value="{{ old('email', $role->getEmail()) }}" required autofocus>
 
+            @if ($errors->has('email'))
+            <p class="help-text">
+                <strong>{{ $errors->first('email') }}</strong>
+            </p>
+            @endif
+        </div>
+    </div>
+
+    <div class="row">
+        <label for="slackChannel" class="form-label">Slack channel</label>
+        <div class="form-control">
+            <input id="slackChannel" type="text" name="slackChannel" value="{{ old('slackChannel', $role->getSlackChannel()) }}" required autofocus>
+
+            @if ($errors->has('slackChannel'))
+            <p class="help-text">
+                <strong>{{ $errors->first('slackChannel') }}</strong>
+            </p>
+            @endif
+        </div>
+    </div>
+
+    <div class="row">
+        <label for="retained" class="form-label">Retained</label>
+        <div class="form-control">
+            <input id="retained" type="checkbox" name="retained"
+            {{ old('retained', $role->getRetained()) ? 'checked="checked"' : '' }}
+            autofocus>
+
+            @if ($errors->has('retained'))
+            <p class="help-text">
+                <strong>{{ $errors->first('retained') }}</strong>
+            </p>
+            @endif
+        </div>
+    </div>
 
 <h2>Permissions</h2>
 

--- a/resources/views/role/show.blade.php
+++ b/resources/views/role/show.blade.php
@@ -46,13 +46,13 @@
 <ul>
 @foreach ($role->getUsers() as $user)
     <li>
-        <form action="{{ route('roles.removeUser', ['roleId' => $role->getId(), 'userId' => $user->getId()]) }}" method="POST">
-            {{ csrf_field() }}
-            {{ method_field('DELETE') }}
-
-            <a href="#" class="alert form-submit-link" aria-label="delete"><i class="fa fa-minus-circle" aria-hidden="true"></i></a>
-            {{ $user->getFullName() }}
+        <a href="javascript:void(0);" onclick="$(this).find('form').submit();" class="alert form-submit-link" aria-label="delete">
+        <form action="{{ route('roles.removeUser', ['roleId' => $role->getId(), 'userId' => $user->getId()]) }}" method="POST" style="display: inline">
+         {{ method_field('DELETE') }}
+         {{ csrf_field() }}
+         <i class="fa fa-minus-circle" aria-hidden="true"></i>
         </form>
+        </a>{{ $user->getFullName() }}
     </li>
 @endforeach
 </ul>

--- a/resources/views/role/show.blade.php
+++ b/resources/views/role/show.blade.php
@@ -13,6 +13,23 @@
                 <th>Description:</th>
                 <td>{{ $role->getDescription() }}</td>
             </tr>
+            <tr>
+                <th>Email:</th>
+                <td>{{ $role->getEmail() }}</td>
+            </tr>
+            <tr>
+                <th>Slack Channel:</th>
+                <td>{{ $role->getSlackChannel() }}</td>
+            </tr>
+            <tr>
+                <th>Retained:</th>
+                <td>@if ($role->getRetained())
+                Yes
+                @else
+                No
+                @endif
+                </td>
+            </tr>
         </tbody>
     </table>
 


### PR DESCRIPTION
Some updates to the Role table and manager 

new columns
* email email address for team roles, used for automatic team email updates and notifications to teams
* slackChannel used to post notifications to team channels
* retained flag for roles that should be retained during member audit changes

Add the first two teams (Membership & Trustees) as there will required notifications during my upcoming registration stuff

rework the user and role managers so generation of events when user is added to/removed from a role can happen in just one file

fixed the front end so the remove user from role buttons work