### PR TITLE
Vagrant: update to php7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ php:
   - 7.1
 
 matrix:
-  allow_failures:
-    - php: 7.1
   fast_finish: true
 
 sudo: false

--- a/dev/vagrant-config/nginx/default
+++ b/dev/vagrant-config/nginx/default
@@ -61,7 +61,7 @@ server {
     location ~ \.php$ {
         include snippets/fastcgi-php.conf;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+        fastcgi_pass unix:/var/run/php/php7.1-fpm.sock;
         fastcgi_read_timeout 300;
     }
 
@@ -73,7 +73,7 @@ server {
             try_files $uri =404;
             root /srv/;
             include /etc/nginx/fastcgi_params;
-            fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
+            fastcgi_pass unix:/var/run/php/php7.1-fpm.sock;
             fastcgi_index index.php;
             fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
             fastcgi_read_timeout 300;

--- a/dev/vagrant-config/scripts/bootstrap.sh
+++ b/dev/vagrant-config/scripts/bootstrap.sh
@@ -8,7 +8,11 @@ export DEBIAN_FRONTEND=noninteractive
 
 apt-get update > /dev/null 2>&1
 
-apt-get install -y software-properties-common vim git curl > /dev/null 2>&1
+apt-get install -y software-properties-common vim git curl apt-transport-https lsb-release ca-certificates> /dev/null 2>&1
+
+# deb.sury.org
+wget --progress=bar:force  -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
 
 # dotDeb
 add-apt-repository -y "deb http://packages.dotdeb.org jessie all"

--- a/dev/vagrant-config/scripts/finish.sh
+++ b/dev/vagrant-config/scripts/finish.sh
@@ -5,7 +5,7 @@ echo "RESTART SERVICES"
 echo " "
 
 service nginx restart
-service php7.0-fpm restart
+service php7.1-fpm restart
 
 echo ""
 echo "------------------------------------------------------------------------"

--- a/dev/vagrant-config/scripts/kerberos.sh
+++ b/dev/vagrant-config/scripts/kerberos.sh
@@ -17,7 +17,7 @@ debconf-set-selections <<< 'krb5-config krb5-config/admin_server string hmsdev.n
 
 
 # Install krb, create passord database, and set the master password to "krbMasterPassword"
-apt-get install php-pear php7.0-dev libkrb5-dev haveged krb5-{admin-server,kdc} -y > /dev/null 2>&1
+apt-get install php-pear php7.1-dev libkrb5-dev haveged krb5-{admin-server,kdc} -y > /dev/null 2>&1
 kdb5_util create -s -P krbMasterPassword
 mkdir /var/log/kerberos
 touch /var/log/kerberos/{krb5kdc,kadmin,krb5lib}.log
@@ -49,6 +49,6 @@ phpize
 make install
 ldconfig
 
-echo "extension=krb5.so" >> /etc/php/7.0/mods-available/krb5.ini
-ln -s /etc/php/7.0/mods-available/krb5.ini /etc/php/7.0/fpm/conf.d/20-krb5.ini 
-ln -s /etc/php/7.0/mods-available/krb5.ini /etc/php/7.0/cli/conf.d/20-krb5.ini 
+echo "extension=krb5.so" >> /etc/php/7.1/mods-available/krb5.ini
+ln -s /etc/php/7.1/mods-available/krb5.ini /etc/php/7.1/fpm/conf.d/20-krb5.ini 
+ln -s /etc/php/7.1/mods-available/krb5.ini /etc/php/7.1/cli/conf.d/20-krb5.ini 

--- a/dev/vagrant-config/scripts/php.sh
+++ b/dev/vagrant-config/scripts/php.sh
@@ -7,14 +7,14 @@ echo " "
 debconf-set-selections <<< 'libssl1.0.0:amd64 libssl1.0.0/restart-services string ntp'
 
 # removing php-pear php-dev as they rely on PHP5
-apt-get install -y haveged php7.0-fpm php7.0-mysql php7.0-apcu php7.0-json php7.0-curl php-mbstring php7.0-xml php7.0-zip php7.0-xdebug > /dev/null 2>&1
+apt-get install -y haveged php7.1-fpm php7.1-mysql php7.1-apcu php7.1-json php7.1-curl php-mbstring php7.1-xml php7.1-zip php7.1-xdebug > /dev/null 2>&1
 
 # set php-fpm to run as "vagrant" user
-sed -i 's/user = www-data/user = vagrant/g' /etc/php/7.0/fpm/pool.d/www.conf
-sed -i 's/group = www-data/group = vagrant/g' /etc/php/7.0/fpm/pool.d/www.conf
-echo 'error_log = /vagrant/storage/logs/php_errors.log' >> /etc/php/7.0/fpm/php.ini
-echo 'xdebug.remote_enable = on' >> /etc/php/7.0/fpm/conf.d/20-xdebug.ini
-echo 'xdebug.remote_connect_back = on' >> /etc/php/7.0/fpm/conf.d/20-xdebug.ini
+sed -i 's/user = www-data/user = vagrant/g' /etc/php/7.1/fpm/pool.d/www.conf
+sed -i 's/group = www-data/group = vagrant/g' /etc/php/7.1/fpm/pool.d/www.conf
+echo 'error_log = /vagrant/storage/logs/php_errors.log' >> /etc/php/7.1/fpm/php.ini
+echo 'xdebug.remote_enable = on' >> /etc/php/7.1/fpm/conf.d/20-xdebug.ini
+echo 'xdebug.remote_connect_back = on' >> /etc/php/7.1/fpm/conf.d/20-xdebug.ini
 
 #phpmyadmin
 cd /srv/


### PR DESCRIPTION
after doing fresh vagrant up one will need to do the following if your working with an existing git clone

```
php artisan cache:clear
php artisan view:clear
```
closes #129 