### PR TITLE
Console: HMS Entity boilerplate creation helpers

### DIFF
--- a/app/Console/Commands/Make/EntityMakeCommand.php
+++ b/app/Console/Commands/Make/EntityMakeCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Console\Commands\Make;
+
+class EntityMakeCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'hms:make:entity
+                            {name : Name of the entity to create}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Entity';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/entity.stub';
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        parent::fire();
+    }
+}

--- a/app/Console/Commands/Make/FactoryMakeCommand.php
+++ b/app/Console/Commands/Make/FactoryMakeCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Console\Commands\Make;
+
+class FactoryMakeCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'hms:make:factory
+                            {name : Name of the entity this factory is for}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Factory';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/factory.stub';
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        parent::fire();
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = parent::buildClass($name);
+        $name = str_replace($this->getDefaultNamespace($name).'\\', '', $name);
+        $dummyFactoryNamspace = $this->rootNamespace().'\\Factories\\'.$name;
+        $dummyFactoryNamspace = trim(implode('\\', array_slice(explode('\\', $dummyFactoryNamspace), 0, -1)), '\\');
+
+        $stub = str_replace('DummyFactoryNamspace',
+            $dummyFactoryNamspace,
+            $stub
+        );
+
+        return $stub;
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $name = str_replace($this->getDefaultNamespace($name).'\\', '', $name);
+
+        return $this->laravel['path'].'/HMS/Factories/'.str_replace('\\', '/', $name).'Factory.php';
+    }
+}

--- a/app/Console/Commands/Make/GeneratorCommand.php
+++ b/app/Console/Commands/Make/GeneratorCommand.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Console\Commands\Make;
+
+use Illuminate\Support\Str;
+use Illuminate\Console\GeneratorCommand as LaravelGeneratorCommand;
+
+abstract class GeneratorCommand extends LaravelGeneratorCommand
+{
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = parent::buildClass($name);
+
+        $stub = str_replace(
+            ['DummyRepositoryInterfaceNamespace',
+            'DummyRepositoryImplementationNamespace',
+            'NamespacedDummyRepositoryInterface',
+            'dummyClass',
+            ],
+            [$this->getRepositoryInterfaceNamespace($name),
+            $this->getRepositoryImplementationNamespace($name),
+            $this->getNamespacedRepositoryInterface($name),
+            $this->getClassInstance($name),
+            ],
+            $stub
+        );
+
+        return $stub;
+    }
+
+    /**
+     * Get the root namespace for the class.
+     *
+     * @return string
+     */
+    protected function rootNamespace()
+    {
+        return 'HMS';
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
+    }
+
+    /**
+     * Get the default namespace for the class.
+     *
+     * @param  string  $rootNamespace
+     * @return string
+     */
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return config('repositories.entity_namespace');
+    }
+
+    /**
+     * Get the namespaced repository interface for the class.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getNamespacedRepositoryInterface($name)
+    {
+        $name = str_replace($this->getDefaultNamespace($name).'\\', '', $name);
+        $interface = config('repositories.repositoriy_namespace') . '\\' . $name . 'Repository';
+
+        return $interface;
+    }
+
+    /**
+     * Get the repository interface namespace for the class.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getRepositoryInterfaceNamespace($name)
+    {
+        $interface = $this->getNamespacedRepositoryInterface($name);
+
+        return trim(implode('\\', array_slice(explode('\\', $interface), 0, -1)), '\\');
+    }
+
+    /**
+     * Get the namespaced repository implementation for the class.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getNamespacedRepositoryImplementation($name)
+    {
+        $name = str_replace($this->getDefaultNamespace($name).'\\', '', $name);
+        $implementation = config('repositories.repositoriy_namespace') . '\\' .
+                (strpos($name, '\\') ? explode('\\', $name)[0] . '\\' : '') .
+                'Doctrine\\Doctrine' .
+                (strpos($name, '\\') ? explode('\\', $name)[1] : $name) .
+                'Repository';
+
+        return $implementation;
+    }
+
+    /**
+     * Get the repository implementation namespace for the class.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getRepositoryImplementationNamespace($name)
+    {
+        $implementation = $this->getNamespacedRepositoryImplementation($name);
+
+        return trim(implode('\\', array_slice(explode('\\', $implementation), 0, -1)), '\\');
+    }
+
+    /**
+     * Get the camelcase name for the class.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getClassInstance($name)
+    {
+        $class = str_replace($this->getNamespace($name).'\\', '', $name);
+
+        return Str::camel($class);
+    }
+}

--- a/app/Console/Commands/Make/MakeCommand.php
+++ b/app/Console/Commands/Make/MakeCommand.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Console\Commands\Make;
+
+use Illuminate\Console\Command;
+
+class MakeCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'hms:make
+                            {name : Name of the entity to create}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Entity/Mapping/Interface/Implementation/Factory all in one go.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $name = trim($this->argument('name'));
+
+        $this->call('hms:make:entity', [
+            'name' => "$name",
+        ]);
+
+        $this->call('hms:make:mapping', [
+            'name' => "$name",
+        ]);
+
+        $this->call('hms:make:repository:interface', [
+            'name' => "$name",
+        ]);
+
+        $this->call('hms:make:repository:implementation', [
+            'name' => "$name",
+        ]);
+
+        $this->call('hms:make:factory', [
+            'name' => "$name",
+        ]);
+    }
+}

--- a/app/Console/Commands/Make/MappingMakeCommand.php
+++ b/app/Console/Commands/Make/MappingMakeCommand.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Console\Commands\Make;
+
+use Illuminate\Support\Str;
+
+class MappingMakeCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'hms:make:mapping
+                            {name : Name of the entity this mapping is for}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Mapping';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/mapping.stub';
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        parent::fire();
+    }
+
+    /**
+     * Build the class with the given name.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function buildClass($name)
+    {
+        $stub = parent::buildClass($name);
+
+        $namspacedDummmyMapping = str_replace('\\', '.', $name);
+
+        $dummyTable = str_replace('\\', '', Str::snake(Str::plural(str_replace($this->getNamespace($name).'\\', '', $name))));
+
+        $stub = str_replace(
+            ['NamspacedDummmyMapping', 'dummyTable'],
+            [$namspacedDummmyMapping, $dummyTable],
+            $stub
+        );
+
+        return $stub;
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $name = str_replace('\\', '.', $name);
+
+        return $this->laravel['path'].'/HMS/Mappings/'.str_replace('\\', '/', $name).'.dcm.yml';
+    }
+}

--- a/app/Console/Commands/Make/RepositoryImplementationMakeCommand.php
+++ b/app/Console/Commands/Make/RepositoryImplementationMakeCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Console\Commands\Make;
+
+class RepositoryImplementationMakeCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'hms:make:repository:implementation
+                            {name : Name of the entity this implementation if for}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Repository Implementation';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/doctrine-repository.stub';
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        parent::fire();
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $name = $this->getNamespacedRepositoryImplementation($name);
+
+        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
+    }
+}

--- a/app/Console/Commands/Make/RepositoryInterfaceMakeCommand.php
+++ b/app/Console/Commands/Make/RepositoryInterfaceMakeCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Console\Commands\Make;
+
+class RepositoryInterfaceMakeCommand extends GeneratorCommand
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'hms:make:repository:interface
+                            {name : Name of the entity this interface is for}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a new Repository Interface';
+
+    /**
+     * Get the stub file for the generator.
+     *
+     * @return string
+     */
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/repository-interface.stub';
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        parent::fire();
+    }
+
+    /**
+     * Get the destination class path.
+     *
+     * @param  string  $name
+     * @return string
+     */
+    protected function getPath($name)
+    {
+        $name = $this->getNamespacedRepositoryInterface($name);
+
+        return $this->laravel['path'].'/'.str_replace('\\', '/', $name).'.php';
+    }
+}

--- a/app/Console/Commands/Make/stubs/doctrine-repository.stub
+++ b/app/Console/Commands/Make/stubs/doctrine-repository.stub
@@ -1,0 +1,20 @@
+<?php
+
+namespace DummyRepositoryImplementationNamespace;
+
+use DummyNamespace\DummyClass;
+use Doctrine\ORM\EntityRepository;
+use NamespacedDummyRepositoryInterface;
+
+class DoctrineDummyClassRepository extends EntityRepository implements DummyClassRepository
+{
+    /**
+     * save DummyClass to the DB. 
+     * @param  DummyClass $dummyClass
+     */
+    public function save(DummyClass $dummyClass)
+    {
+        $this->_em->persist($dummyClass);
+        $this->_em->flush();
+    }
+}

--- a/app/Console/Commands/Make/stubs/entity.stub
+++ b/app/Console/Commands/Make/stubs/entity.stub
@@ -1,0 +1,21 @@
+<?php
+
+namespace DummyNamespace;
+
+class DummyClass
+{
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * Gets the value of id.
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/app/Console/Commands/Make/stubs/factory.stub
+++ b/app/Console/Commands/Make/stubs/factory.stub
@@ -1,0 +1,32 @@
+<?php
+
+namespace DummyFactoryNamspace;
+
+use DummyNamespace\DummyClass;
+use NamespacedDummyRepositoryInterface;
+
+class DummyClassFactory
+{
+    /**
+     * @var DummyClassRepository
+     */
+    protected $dummyClassRepository;
+
+    /**
+     * @param DummyClassRepository $dummyClassRepository
+     */
+    public function __construct(DummyClassRepository $dummyClassRepository)
+    {
+        $this->dummyClassRepository = $dummyClassRepository;
+    }
+
+    /**
+     * Function to instantiate a new DummyClass from given params.
+     */
+    public function create()
+    {
+        $_dummyClass = new DummyClass();
+
+        return $_dummyClass;
+    }
+}

--- a/app/Console/Commands/Make/stubs/mapping.stub
+++ b/app/Console/Commands/Make/stubs/mapping.stub
@@ -1,0 +1,12 @@
+# NamspacedDummmyMapping.dcm.yml
+DummyNamespace\DummyClass:
+  type: entity
+  repositoryClass: NamespacedDummyRepositoryInterface
+  table: dummyTable
+  id:
+    id:
+      type: integer
+      options:
+        unsigned: true
+      generator:
+        strategy: AUTO

--- a/app/Console/Commands/Make/stubs/repository-interface.stub
+++ b/app/Console/Commands/Make/stubs/repository-interface.stub
@@ -1,0 +1,14 @@
+<?php
+
+namespace DummyRepositoryInterfaceNamespace;
+
+use DummyNamespace\DummyClass;
+
+interface DummyClassRepository
+{
+    /**
+     * save DummyClass to the DB.
+     * @param  DummyClass $dummyClass
+     */
+    public function save(DummyClass $dummyClass);
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -19,6 +19,12 @@ class Kernel extends ConsoleKernel
         Commands\Permissions\StripCommand::class,
         Commands\Invites\PurgeCommand::class,
         Commands\Permissions\DefaultsCommand::class,
+        Commands\Make\MakeCommand::class,
+        Commands\Make\EntityMakeCommand::class,
+        Commands\Make\MappingMakeCommand::class,
+        Commands\Make\RepositoryInterfaceMakeCommand::class,
+        Commands\Make\RepositoryImplementationMakeCommand::class,
+        Commands\Make\FactoryMakeCommand::class,
     ];
 
     /**


### PR DESCRIPTION
Usage:
`php artisan hms:make GateKeeper/RfidTag`

`hms:make` will create boilerplate files for Entity, Mapping, Repository Interface, Repository Implementation (docrtine) and Factory

each file can also be generated individually using the appropriate command from below

```
  hms:make                            Create a new Entity/Mapping/Interface/Implementation/Factory all in one go.
  hms:make:entity                     Create a new Entity
  hms:make:factory                    Create a new Factory
  hms:make:mapping                    Create a new Mapping
  hms:make:repository:implementation  Create a new Repository Implementation
  hms:make:repository:interface       Create a new Repository Interface
```