### PR TITLE
Frontend: Use CSRF token from meta tag, instead of window.Laravel object

### DIFF
--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -12,7 +12,7 @@ $(() => {
 
 $.ajaxSetup({
    headers: {
-     'X-CSRF-Token': window.Laravel.csrfToken,
+     'X-CSRF-Token': document.head.querySelector('meta[name="csrf-token"]').content,
    }
 });
 

--- a/resources/assets/js/bootstrap.js
+++ b/resources/assets/js/bootstrap.js
@@ -21,7 +21,7 @@ try {
 
 window.axios = require('axios');
 
-window.axios.defaults.headers.common['X-CSRF-TOKEN'] = window.Laravel.csrfToken;
+window.axios.defaults.headers.common['X-CSRF-TOKEN'] = document.head.querySelector('meta[name="csrf-token"]').content;
 window.axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
 
 /**

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -19,12 +19,6 @@
     <link href="{{ mix('css/app.css') }}" rel="stylesheet">
 
     <!-- Scripts -->
-    <script>
-        window.Laravel = <?php echo json_encode([
-            'csrfToken' => csrf_token(),
-        ]); ?>
-    </script>
-
     <!-- Font Awesome -->
     <script src="https://use.fontawesome.com/5fd8ad5172.js"></script>
 </head>


### PR DESCRIPTION
as per changed in laravel 5.4.23
https://github.com/laravel/laravel/pull/4260
