### PR TITLE
Date format work around to change dd/mm/yyyy to yyyy-mm-dd on submit

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -84,7 +84,7 @@ class RegisterController extends Controller
             'addressCounty' => 'required|max:100',
             'addressPostcode' => 'required|max:10',
             'contactNumber' => 'required|max:50',
-            'dateOfBirth' => 'nullable|date',
+            'dateOfBirth' => 'nullable|date_format:Y-m-d',
         ]);
     }
 

--- a/app/Http/Controllers/MembershipController.php
+++ b/app/Http/Controllers/MembershipController.php
@@ -208,7 +208,7 @@ class MembershipController extends Controller
             'addressCounty' => 'required|max:100',
             'addressPostcode' => 'required|max:10',
             'contactNumber' => 'required|max:50',
-            'dateOfBirth' => 'nullable|date',
+            'dateOfBirth' => 'nullable|date_format:Y-m-d',
         ]);
 
         $user = $this->userManager->updateFromRequest($user, $request);

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -109,7 +109,7 @@ class UserController extends Controller
             'addressCounty' => 'sometimes|required|max:100',
             'addressPostcode' => 'sometimes|required|max:10',
             'contactNumber' => 'sometimes|required|max:50',
-            'dateOfBirth' => 'sometimes|nullable|date',
+            'dateOfBirth' => 'sometimes|nullable|date_format:Y-m-d',
             'unlockText' => 'sometimes|nullable|max:95',
         ]);
 

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -76,3 +76,11 @@ function formatUser (user) {
 function formatUserSelection (user) {
   return user.fullname;
 }
+
+// Workaround to reformat sumbited date's into ISO if there in UK format
+$("#user-edit-form,#membership-edit-details-form,#register-form").submit(function() {
+  var date = $("input[type='date']");
+  if (date.val().includes('/')) {
+    date.val(date.val().split('/').reverse().join('-'));
+  }
+});

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -4,7 +4,7 @@
 
 @section('content')
 
-<form role="form" method="POST" action="{{ url('/register') }}">
+<form id="register-form" role="form" method="POST" action="{{ url('/register') }}">
   {{ csrf_field() }}
   <input type="hidden" name="invite" value="{{ old('invite', $invite) }}" >
   @if ($errors->has('invite'))

--- a/resources/views/membership/editDetails.blade.php
+++ b/resources/views/membership/editDetails.blade.php
@@ -5,7 +5,7 @@
 @section('content')
 <p>Please review the details below and update them as requested by the membership team.</p>
 
-<form role="form" method="POST" action="{{ route('membership.update', $user->getId()) }}">
+<form id="membership-edit-details-form" role="form" method="POST" action="{{ route('membership.update', $user->getId()) }}">
   {{ csrf_field() }}
   {{ method_field('PUT') }}
 

--- a/resources/views/user/edit.blade.php
+++ b/resources/views/user/edit.blade.php
@@ -3,7 +3,7 @@
 @section('pageTitle', $user->getFullName())
 
 @section('content')
-<form role="form" method="POST" action="{{ route('users.update', $user->getId()) }}">
+<form id="user-edit-form" role="form" method="POST" action="{{ route('users.update', $user->getId()) }}">
   {{ csrf_field() }}
   {{ method_field('PUT') }}
 


### PR DESCRIPTION
We should be sending everything over the wire in ISO_8601 format, but as we don't yet have date pikers for all browsers this catches anyone trying to submit a UK format