### PR TITLE
Overhaul navigation

### DIFF
--- a/app/HMS/Composers/NavComposer.php
+++ b/app/HMS/Composers/NavComposer.php
@@ -82,11 +82,15 @@ class NavComposer
             // populate the array if they can
             if ($allowed) {
                 $link = [
-                    'url'       =>  route($navItem['route']),
+                    'url'       => '#',
                     'text'      =>  $navItem['text'],
                     'active'    =>  false,
                     'links'     =>  [],
                 ];
+
+                if (isset($navItem['route'])) {
+                    $link['url'] = route($navItem['route']);
+                }
 
                 // is the current route part of this link?
                 // multiple routes can set a link as "active"
@@ -102,7 +106,11 @@ class NavComposer
                     $link['links'] = $this->buildLinks($navItem['links'], $user);
                 }
 
-                $links[] = $link;
+                if (count($navItem['links']) > 0 && count($link['links']) == 0) {
+                    continue;
+                } else {
+                    $links[] = $link;
+                }
             }
         }
 

--- a/config/navigation.php
+++ b/config/navigation.php
@@ -32,7 +32,6 @@ return [
         ],
         'admin' => [
             'text'          => 'Admin',
-            'route'         => 'admin',
             'permissions'   => [],
             'links'         => [
                 'roles'         => [

--- a/database/seeds/UserTableSeeder.php
+++ b/database/seeds/UserTableSeeder.php
@@ -72,6 +72,7 @@ class UserTableSeeder extends Seeder
             ->make()
             ->each(function ($u) {
                 $u->getRoles()->add($this->roleRepository->findOneByName(Role::MEMBER_CURRENT));
+                $this->passwordStore->add($u->getUsername(), 'password');
                 EntityManager::persist($u);
             });
 
@@ -81,6 +82,7 @@ class UserTableSeeder extends Seeder
                 ->make()
                 ->each(function ($u) use ($role) {
                     $u->getRoles()->add($this->roleRepository->findOneByName($role));
+                    $this->passwordStore->add($u->getUsername(), 'password');
                     EntityManager::persist($u);
                 });
         }

--- a/dev/vagrant-config/laravel/.env
+++ b/dev/vagrant-config/laravel/.env
@@ -1,4 +1,4 @@
-APP_NAME="Hackspace Managment System"
+APP_NAME="Hackspace Management System"
 APP_ENV=local
 APP_KEY=base64:q2bOreAmmB2+pbokHPTLV81whgZQ9/RGRkcra1FUhmo=
 APP_DEBUG=true

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -100,6 +100,25 @@ header {
     align-items: center;
 }
 
+
+
+/*
+ * Ensure the nav objects don't flash in before the JavaScript which controls their visibility executes
+ */
+@include breakpoint(small only) {
+  .main-menu {
+    display: none;
+  }
+}
+
+@include breakpoint(medium) {
+  .title-bar {
+    display: none;
+  }
+}
+
+
+
 // Spacing classes
 // ---------------
 // Utility classes for spacing things around in special circumstances

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -27,6 +27,7 @@ h2 {
 
 .content {
     flex: 1;
+    margin-top: 2rem;
     padding-bottom: rem-calc(20);
 }
 
@@ -47,7 +48,6 @@ ul.nomarkers {
 
 header {
     box-shadow: 0px 1px 8px rgba(0, 0, 0, 0.5);
-    margin-bottom: 2rem;
 }
 
 .header {
@@ -100,22 +100,33 @@ header {
     align-items: center;
 }
 
-
-
 /*
- * Ensure the nav objects don't flash in before the JavaScript which controls their visibility executes
+ * Navigation classes and objects need to show/hide in the right circumstances
  */
 @include breakpoint(small only) {
-  .main-menu {
+  // In small screens, the main menu is hidden and the mobile menu is showable
+  #main-menu {
     display: none;
+  }
+
+  // This selector must be more specific than the ID selector which hides the menu
+  #mobile-menu.show-mobile-menu {
+    display: block;
   }
 }
 
 @include breakpoint(medium) {
-  .title-bar {
+  // In medium+, the mobile menu's toggle button is hidden
+  .mobile-menu-button {
     display: none;
   }
 }
+
+// The default visibility of the mobile menu is hidden
+#mobile-menu {
+  display: none;
+}
+
 
 
 

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -31,6 +31,20 @@ h2 {
     padding-bottom: rem-calc(20);
 }
 
+@include breakpoint(small only) {
+  .content {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+}
+
+@include breakpoint(medium) {
+  .content {
+    padding-left: 2rem;
+    padding-right: 2rem;
+  }
+}
+
 ul.nomarkers {
     list-style-type: none;
     margin-left: 0;

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -141,6 +141,11 @@ header {
   display: none;
 }
 
+.no-js {
+ .submenu {
+   display: none;
+  }
+}
 
 
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -57,7 +57,7 @@
           <button data-toggle="mobile-menu" type="button"><i class="fa fa-bars" aria-hidden="true"></i> Menu</button>
         </div>
 
-        {{-- build the menu for medium+ screens --}}
+        {{-- build the meu for medium+ screens --}}
         <div class="columns show-for-medium" id="main-menu">
           <ul class="dropdown menu" data-dropdown-menu>
             @foreach ($mainNav as $link)
@@ -120,7 +120,7 @@
   @include('partials.flash')
 
 
-  <div class="row expanded align-top">
+  <div class="row align-top">
     <div class="small-12 medium-expand columns">
       @yield('content')
     </div>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -52,8 +52,28 @@
 
     <div class="row expanded align-middle userbar">
       @if (!Auth::guest() and isset($mainNav) )
-        <div class="columns" data-responsive-toggle="main-menu" data-hide-for="medium">
-          <button data-toggle="main-menu" type="button"><i class="fa fa-bars" aria-hidden="true"></i> Menu</button>
+        {{-- build the menu toggle for small screens --}}
+        <div class="mobile-menu-button columns hide-for-medium">
+          <button data-toggle="mobile-menu" type="button"><i class="fa fa-bars" aria-hidden="true"></i> Menu</button>
+        </div>
+
+        {{-- build the menu for medium+ screens --}}
+        <div class="columns show-for-medium" id="main-menu">
+          <ul class="dropdown menu" data-dropdown-menu>
+            @foreach ($mainNav as $link)
+              <li{!! $link['active'] ? ' class="active"' : '' !!}><a href="{{ $link['url'] }}">{{ $link['text'] }}</a>
+                @if ( count($link['links']) > 0 )
+                  {{-- put hide-for-small on submenus so that before the JS comes in they won't flash up.
+                       Once the JS kicks in, it overrides visibility controls so the drop down will show perfectly --}}
+                  <ul class="menu hide-for-small">
+                    @foreach ($link['links'] as $subLink)
+                      <li{!! $subLink['active'] ? ' class="active"' : '' !!}><a href="{{ $subLink['url'] }}">{{ $subLink['text'] }}</a></li>
+                    @endforeach
+                  </ul>
+                @endif
+              </li>
+            @endforeach
+          </ul>
         </div>
       @endif
 
@@ -76,39 +96,38 @@
     </div>
   </header>
 
+{{-- build the menu for small screens --}}
+<div id="mobile-menu" data-toggler="show-mobile-menu">
+  <ul class="vertical menu" data-accordion-menu>
+    @foreach ($mainNav as $link)
+      <li{!! $link['active'] ? ' class="active"' : '' !!}><a href="{{ $link['url'] }}">{{ $link['text'] }}</a>
+        @if ( count($link['links']) > 0 )
+          <ul class="vertical nested menu">
+            @foreach ($link['links'] as $subLink)
+              <li{!! $subLink['active'] ? ' class="active"' : '' !!}><a href="{{ $subLink['url'] }}">{{ $subLink['text'] }}</a></li>
+            @endforeach
+          </ul>
+        @endif
+      </li>
+    @endforeach
+  </ul>
+</div>
+
   <!-- main body -->
   <div class="content">
+
 
   @include('partials.flash')
 
 
   <div class="row expanded align-top">
-      @if (!Auth::guest() and isset($mainNav))
-          <div class="small-12 medium-2 columns" id="main-menu">
-            <ul class="vertical menu">
-              @foreach ($mainNav as $link)
-                <li{!! $link['active'] ? ' class="active"' : '' !!}><a href="{{ $link['url'] }}">{{ $link['text'] }}</a></li>
-                @if ( count($link['links']) > 0 )
-                  <ul class="nested vertical menu">
-                    @foreach ($link['links'] as $subLink)
-                      <li{!! $subLink['active'] ? ' class="active"' : '' !!}><a href="{{ $subLink['url'] }}">{{ $subLink['text'] }}</a></li>
-                    @endforeach
-                  </ul>
-                @endif
-              @endforeach
-            </ul>
-          </div>
-      @endif
-
-      <div class="small-12 medium-expand columns">
-        @yield('content')
-      </div>
+    <div class="small-12 medium-expand columns">
+      @yield('content')
     </div>
 
     <div class="row">
       @include('cookieConsent::index')
     </div>
-
   </div>
 
   <!-- footer -->

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" class="no-js">
 <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -65,7 +65,7 @@
                 @if ( count($link['links']) > 0 )
                   {{-- put hide-for-small on submenus so that before the JS comes in they won't flash up.
                        Once the JS kicks in, it overrides visibility controls so the drop down will show perfectly --}}
-                  <ul class="menu hide">
+                  <ul class="menu submenu">
                     @foreach ($link['links'] as $subLink)
                       <li{!! $subLink['active'] ? ' class="active"' : '' !!}><a href="{{ $subLink['url'] }}">{{ $subLink['text'] }}</a></li>
                     @endforeach

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -63,8 +63,6 @@
             @foreach ($mainNav as $link)
               <li{!! $link['active'] ? ' class="active"' : '' !!}><a href="{{ $link['url'] }}">{{ $link['text'] }}</a>
                 @if ( count($link['links']) > 0 )
-                  {{-- put hide-for-small on submenus so that before the JS comes in they won't flash up.
-                       Once the JS kicks in, it overrides visibility controls so the drop down will show perfectly --}}
                   <ul class="menu submenu">
                     @foreach ($link['links'] as $subLink)
                       <li{!! $subLink['active'] ? ' class="active"' : '' !!}><a href="{{ $subLink['url'] }}">{{ $subLink['text'] }}</a></li>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -65,7 +65,7 @@
                 @if ( count($link['links']) > 0 )
                   {{-- put hide-for-small on submenus so that before the JS comes in they won't flash up.
                        Once the JS kicks in, it overrides visibility controls so the drop down will show perfectly --}}
-                  <ul class="menu hide-for-small">
+                  <ul class="menu hide">
                     @foreach ($link['links'] as $subLink)
                       <li{!! $subLink['active'] ? ' class="active"' : '' !!}><a href="{{ $subLink['url'] }}">{{ $subLink['text'] }}</a></li>
                     @endforeach

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -50,8 +50,14 @@
       </div>
     </div>
 
-    <div class="row expanded userbar">
-      <ul class="menu align-right">
+    <div class="row expanded align-middle userbar">
+      @if (!Auth::guest() and isset($mainNav) )
+        <div class="columns" data-responsive-toggle="main-menu" data-hide-for="medium">
+          <button data-toggle="main-menu" type="button"><i class="fa fa-bars" aria-hidden="true"></i> Menu</button>
+        </div>
+      @endif
+
+      <ul class="columns menu align-right">
         @if (Auth::guest())
         <li><a href="{{ url('/login') }}">Log In</a></li>
         @if (SiteVisitor::inTheSpace())
@@ -75,41 +81,28 @@
 
   @include('partials.flash')
 
-  <div class="row align-top">
-      @if (!Auth::guest())
-      <div class="columns small-12 small-order-1 medium-2 medium-order-0 large-2">
 
-        @if ( isset($mainNav) )
+  <div class="row expanded align-top">
+      @if (!Auth::guest() and isset($mainNav))
+          <div class="small-12 medium-2 columns" id="main-menu">
             <ul class="vertical menu">
-            @foreach ($mainNav as $link)
+              @foreach ($mainNav as $link)
                 <li{!! $link['active'] ? ' class="active"' : '' !!}><a href="{{ $link['url'] }}">{{ $link['text'] }}</a></li>
                 @if ( count($link['links']) > 0 )
-                    <ul class="nested vertical menu">
+                  <ul class="nested vertical menu">
                     @foreach ($link['links'] as $subLink)
-                        <li{!! $subLink['active'] ? ' class="active"' : '' !!}><a href="{{ $subLink['url'] }}">{{ $subLink['text'] }}</a></li>
+                      <li{!! $subLink['active'] ? ' class="active"' : '' !!}><a href="{{ $subLink['url'] }}">{{ $subLink['text'] }}</a></li>
                     @endforeach
-                    </ul>
+                  </ul>
                 @endif
-            @endforeach
+              @endforeach
             </ul>
-        @endif
-      </div>
+          </div>
       @endif
 
-      @if (Auth::guest())
-      <div class="columns">
-      @else
-      <div class="columns small-12 small-order-0 medium-10 medium-order-1 large-7">
-      @endif
+      <div class="small-12 medium-expand columns">
         @yield('content')
       </div>
-
-      @if (!Auth::guest())
-      <div class="columns small-12 small-order-3 medium-12 medium-order-2 large-3">
-        <!-- this is where upcoming tool bookings might go -->
-      </div>
-      @endif
-
     </div>
 
     <div class="row">

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -113,9 +113,8 @@
   </ul>
 </div>
 
-  <!-- main body -->
-  <div class="content">
-
+<!-- main body -->
+<div class="content">
 
   @include('partials.flash')
 
@@ -129,6 +128,7 @@
       @include('cookieConsent::index')
     </div>
   </div>
+</div>
 
   <!-- footer -->
   <footer>


### PR DESCRIPTION
Move navigation to be a menu bar, except on small screens where you get a Menu button to press which shows a nice vertical menu instead.

The menu bar has dropdowns for sub-items such as in Admin, and the small screen menu puts those in an expandable accordion.

This had a number of ripple effects through the overall page structure, moving some margins and padding etc. around so that the small screen menu would appear neatly in the right place.