### PR TITLE
Extract enums for entites

### DIFF
--- a/app/HMS/Entities/GateKeeper/Pin.php
+++ b/app/HMS/Entities/GateKeeper/Pin.php
@@ -8,35 +8,6 @@ use HMS\Entities\User;
 class Pin
 {
     /**
-     * This pin can be used for entry (up until the expiry date), cannot be used to register a card.
-     */
-    const STATE_ACTIVE = 10;
-
-    /**
-     * Pin has expired and can no longer be used for entry.
-     */
-    const STATE_EXPIRED = 20;
-
-    /**
-     * This pin cannot be used for entry, and has likely been used to activate an RFID card.
-     */
-    const STATE_CANCELLED = 30;
-
-    /**
-     * This pin may be used to enrol an RFID card.
-     */
-    const STATE_ENROLL = 40;
-    /**
-     * String representation of states for display.
-     */
-    public $statusStrings = [
-                                  10 => 'Active',
-                                  20 => 'Expired',
-                                  30 => 'Cancelled',
-                                  40 => 'Enroll',
-                                  ];
-
-    /**
      * @var int
      */
     protected $id;
@@ -65,7 +36,7 @@ class Pin
      * @param string $pin
      * @param int $state
      */
-    public function __construct(string $pin, int $state = self::STATE_ACTIVE)
+    public function __construct(string $pin, int $state = PinState::ACTIVE)
     {
         $this->pin = $pin;
         $this->state = $state;
@@ -172,7 +143,7 @@ class Pin
      */
     public function setState($state)
     {
-        if (in_array($state, array_keys($this->statusStrings))) {
+        if (array_key_exists($state, PinState::STATE_STRINGS)) {
             $this->state = $state;
         }
 
@@ -186,7 +157,7 @@ class Pin
      */
     public function setStateCancelled()
     {
-        $this->state = self::STATE_CANCELLED;
+        $this->state = PinState::CANCELLED;
 
         return $this;
     }
@@ -198,7 +169,7 @@ class Pin
      */
     public function setStateEnroll()
     {
-        $this->state = self::STATE_ENROLL;
+        $this->state = PinState::ENROLL;
 
         return $this;
     }

--- a/app/HMS/Entities/GateKeeper/PinState.php
+++ b/app/HMS/Entities/GateKeeper/PinState.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace HMS\Entities\GateKeeper;
+
+abstract class PinState
+{
+    /**
+     * This pin can be used for entry (up until the expiry date), cannot be used to register a card.
+     */
+    const ACTIVE = 10;
+
+    /**
+     * Pin has expired and can no longer be used for entry.
+     */
+    const EXPIRED = 20;
+
+    /**
+     * This pin cannot be used for entry, and has likely been used to activate an RFID card.
+     */
+    const CANCELLED = 30;
+
+    /**
+     * This pin may be used to enrol an RFID card.
+     */
+    const ENROLL = 40;
+
+    /**
+     * String representation of states for display.
+     */
+    const STATE_STRINGS =
+    [
+        self::ACTIVE => 'Active',
+        self::EXPIRED => 'Expired',
+        self::CANCELLED => 'Cancelled',
+        self::ENROLL => 'Enroll',
+    ];
+}

--- a/app/HMS/Entities/GateKeeper/RfidTag.php
+++ b/app/HMS/Entities/GateKeeper/RfidTag.php
@@ -7,30 +7,6 @@ use HMS\Entities\User;
 class RfidTag
 {
     /**
-     * This RfidTag can be used for entry (up until the expiry date), cannot be used to register a card.
-     */
-    const STATE_ACTIVE = 10;
-
-    /**
-     * RfidTag has expired and can no longer be used for entry.
-     */
-    const STATE_EXPIRED = 20;
-
-    /**
-     * RfidTag has been lost and can no longer be used for entry.
-     */
-    const STATE_LOST = 30;
-
-    /**
-     * String representation of states for display.
-     */
-    public $statusStrings = [
-                                  10 => 'Active',
-                                  20 => 'Expired',
-                                  30 => 'Lost',
-                                  ];
-
-    /**
      * @var int
      */
     protected $id;
@@ -142,7 +118,7 @@ class RfidTag
      */
     public function setState($state)
     {
-        if (in_array($state, array_keys($this->statusStrings))) {
+        if (array_key_exists($state, RfidTagState::STATE_STRINGS)) {
             $this->state = $state;
         }
 

--- a/app/HMS/Entities/GateKeeper/RfidTagState.php
+++ b/app/HMS/Entities/GateKeeper/RfidTagState.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace HMS\Entities\GateKeeper;
+
+abstract class RfidTagState
+{
+    /**
+     * This RfidTag can be used for entry (up until the expiry date), cannot be used to register a card.
+     */
+    const ACTIVE = 10;
+
+    /**
+     * RfidTag has expired and can no longer be used for entry.
+     */
+    const EXPIRED = 20;
+
+    /**
+     * RfidTag has been lost and can no longer be used for entry.
+     */
+    const LOST = 30;
+
+    /**
+     * String representation of states for display.
+     */
+    const STATE_STRINGS =
+    [
+        self::ACTIVE => 'Active',
+        self::EXPIRED => 'Expired',
+        self::LOST => 'Lost',
+    ];
+}

--- a/app/HMS/Entities/Members/Project.php
+++ b/app/HMS/Entities/Members/Project.php
@@ -8,30 +8,6 @@ use HMS\Entities\User;
 class Project
 {
     /**
-     * This projcet is considered active and being worked on.
-     */
-    const PROJCET_ACTIVE = 10;
-
-    /**
-     * Project has been finished/removed from the hackspace.
-     */
-    const PROJCET_COMPLETE = 20;
-
-    /**
-     * Project has been identified as abandoned and not beeing worked on.
-     */
-    const PROJCET_ABANDONED = 30;
-
-    /**
-     * String representation of states for display.
-     */
-    public $statusStrings = [
-        10 => 'Active',
-        20 => 'Complete',
-        30 => 'Abandoned',
-    ];
-
-    /**
      * @var int
      */
     protected $id;
@@ -143,7 +119,7 @@ class Project
      */
     public function getStateString()
     {
-        return $this->statusStrings[$this->state];
+        return ProjectState::STATE_STRINGS[$this->state];
     }
 
     /**
@@ -181,7 +157,9 @@ class Project
      */
     public function setState($state)
     {
-        $this->state = $state;
+        if (array_key_exists($state, ProjectState::STATE_STRINGS)) {
+            $this->state = $state;
+        }
 
         return $this;
     }
@@ -191,7 +169,7 @@ class Project
      */
     public function setStateActive()
     {
-        $this->state = self::PROJCET_ACTIVE;
+        $this->state = ProjectState::ACTIVE;
         $this->completeDate = null;
 
         return $this;
@@ -202,7 +180,7 @@ class Project
      */
     public function setStateComplete()
     {
-        $this->state = self::PROJCET_COMPLETE;
+        $this->state = ProjectState::COMPLETE;
         $this->completeDate = Carbon::now();
 
         return $this;
@@ -213,7 +191,7 @@ class Project
      */
     public function setStateAbandoned()
     {
-        $this->state = self::PROJCET_ABANDONED;
+        $this->state = ProjectState::ABANDONED;
         $this->completeDate = Carbon::now();
 
         return $this;

--- a/app/HMS/Entities/Members/ProjectState.php
+++ b/app/HMS/Entities/Members/ProjectState.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace HMS\Entities\Members;
+
+class ProjectState
+{
+    /**
+     * This project is considered active and being worked on.
+     */
+    const ACTIVE = 10;
+
+    /**
+     * Project has been finished/removed from the hackspace.
+     */
+    const COMPLETE = 20;
+
+    /**
+     * Project has been identified as abandoned and not beeing worked on.
+     */
+    const ABANDONED = 30;
+
+    /**
+     * String representation of states for display.
+     */
+    const STATE_STRINGS =
+    [
+        self::ACTIVE => 'Active',
+        self::COMPLETE => 'Complete',
+        self::ABANDONED => 'Abandoned',
+    ];
+}

--- a/app/HMS/Entities/Snackspace/Transaction.php
+++ b/app/HMS/Entities/Snackspace/Transaction.php
@@ -7,14 +7,6 @@ use HMS\Entities\User;
 
 class Transaction
 {
-    const TYPE_VEND = 'VEND';           // Transaction relates to either vending machine purchace, or a payment received by note acceptor
-    const TYPE_MANUAL = 'MANUAL';   // Transaction is a manually entered (via web interface) record of a payment or purchase
-    const TYPE_TOOL = 'TOOL';
-    const TYPE_MEMBERBOX = 'BOX';
-
-    const STATE_COMPLETE = 'COMPLETE';
-    const STATE_PENDING = 'PENDING';
-
     /**
      * @var int
      */
@@ -67,7 +59,7 @@ class Transaction
      * @param int    $amount
      * @param string $status
      */
-    public function __construct(User $user, int $amount, string $status = self::STATE_PENDING)
+    public function __construct(User $user, int $amount, string $status = TransactionState::PENDING)
     {
         $this->user = $user;
         $this->amount = $amount;

--- a/app/HMS/Entities/Snackspace/TransactionState.php
+++ b/app/HMS/Entities/Snackspace/TransactionState.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace HMS\Entities\Snackspace;
+
+abstract class TransactionState
+{
+    const COMPLETE = 'COMPLETE';
+    const PENDING = 'PENDING';
+}

--- a/app/HMS/Entities/Snackspace/TransactionType.php
+++ b/app/HMS/Entities/Snackspace/TransactionType.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace HMS\Entities\Snackspace;
+
+abstract class TransactionType
+{
+    const VEND = 'VEND';     // Transaction relates to either vending machine purchace, or a payment received by note acceptor
+    const MANUAL = 'MANUAL'; // Transaction is a manually entered (via web interface) record of a payment or purchase
+    const TOOL = 'TOOL';
+    const MEMBER_BOX = 'BOX';
+}

--- a/app/HMS/Factories/GateKeeper/PinFactory.php
+++ b/app/HMS/Factories/GateKeeper/PinFactory.php
@@ -2,6 +2,7 @@
 
 namespace HMS\Factories\GateKeeper;
 
+use HMS\Entities\GateKeeper\PinState;
 use HMS\Entities\User;
 use HMS\Entities\GateKeeper\Pin;
 use HMS\Repositories\GateKeeper\PinRepository;
@@ -29,7 +30,7 @@ class PinFactory
      */
     public function createNewEnrollPinForUser(User $user)
     {
-        $pin = new Pin((string) $this->generateUniquePin(), Pin::STATE_ENROLL);
+        $pin = new Pin((string) $this->generateUniquePin(), PinState::ENROLL);
         $pin->setUser($user);
 
         return $pin;

--- a/app/HMS/Factories/GateKeeper/PinFactory.php
+++ b/app/HMS/Factories/GateKeeper/PinFactory.php
@@ -2,9 +2,9 @@
 
 namespace HMS\Factories\GateKeeper;
 
-use HMS\Entities\GateKeeper\PinState;
 use HMS\Entities\User;
 use HMS\Entities\GateKeeper\Pin;
+use HMS\Entities\GateKeeper\PinState;
 use HMS\Repositories\GateKeeper\PinRepository;
 
 class PinFactory

--- a/app/HMS/Repositories/Snackspace/Doctrine/DoctrineTransactionRepository.php
+++ b/app/HMS/Repositories/Snackspace/Doctrine/DoctrineTransactionRepository.php
@@ -2,10 +2,10 @@
 
 namespace HMS\Repositories\Snackspace\Doctrine;
 
+use HMS\Entities\User;
 use Doctrine\ORM\EntityRepository;
 use HMS\Entities\Snackspace\Transaction;
 use HMS\Entities\Snackspace\TransactionState;
-use HMS\Entities\User;
 use HMS\Repositories\Snackspace\TransactionRepository;
 use LaravelDoctrine\ORM\Pagination\PaginatesFromRequest;
 

--- a/app/HMS/Repositories/Snackspace/Doctrine/DoctrineTransactionRepository.php
+++ b/app/HMS/Repositories/Snackspace/Doctrine/DoctrineTransactionRepository.php
@@ -2,9 +2,10 @@
 
 namespace HMS\Repositories\Snackspace\Doctrine;
 
-use HMS\Entities\User;
 use Doctrine\ORM\EntityRepository;
 use HMS\Entities\Snackspace\Transaction;
+use HMS\Entities\Snackspace\TransactionState;
+use HMS\Entities\User;
 use HMS\Repositories\Snackspace\TransactionRepository;
 use LaravelDoctrine\ORM\Pagination\PaginatesFromRequest;
 
@@ -40,7 +41,7 @@ class DoctrineTransactionRepository extends EntityRepository implements Transact
     public function saveAndUpdateBalance(Transaction $transaction)
     {
         $transaction->getUser()->getProfile()->updateBalanceByAmount($transaction->getAmount());
-        $transaction->setStatus(Transaction::STATE_COMPLETE);
+        $transaction->setStatus(TransactionState::COMPLETE);
         $this->_em->persist($transaction);
         $this->_em->flush();
 

--- a/resources/views/members/project/index.blade.php
+++ b/resources/views/members/project/index.blade.php
@@ -35,12 +35,12 @@ Projects for {{ $user->getFirstname() }}
       <a href="{{ route('projects.show', $project->getId()) }}"><i class="fa fa-eye" aria-hidden="true"></i> View Project</a><br/>
       @endcan
       @can('project.printLabel.self')
-        @if (SiteVisitor::inTheSpace() && $project->getState() == \HMS\Entities\Members\Project::PROJCET_ACTIVE)
+        @if (SiteVisitor::inTheSpace() && $project->getState() == \HMS\Entities\Members\ProjectState::ACTIVE)
         <a href="{{ route('projects.print', $project->getId()) }}"><i class="fa fa-print" aria-hidden="true"></i> Print Do-Not-Hack Label</a><br />
         @endif
       @endcan
       @can('project.edit.self')
-        @if ($project->getState() == \HMS\Entities\Members\Project::PROJCET_ACTIVE)
+        @if ($project->getState() == \HMS\Entities\Members\ProjectState::ACTIVE)
           @if ($project->getUser() == \Auth::user())
           <a href="javascript:void(0);" onclick="$(this).find('form').submit();">
             <form action="{{ route('projects.markComplete', $project->getId()) }}" method="POST" style="display: none">
@@ -59,7 +59,7 @@ Projects for {{ $user->getFirstname() }}
           </a><br />
           @endif
         @endif
-        @if ($project->getState() != \HMS\Entities\Members\Project::PROJCET_ACTIVE)
+        @if ($project->getState() != \HMS\Entities\Members\ProjectState::ACTIVE)
         <a href="javascript:void(0);" onclick="$(this).find('form').submit();">
           <form action="{{ route('projects.markActive', $project->getId()) }}" method="POST" style="display: none">
             {{ method_field('PATCH') }}

--- a/resources/views/members/project/show.blade.php
+++ b/resources/views/members/project/show.blade.php
@@ -35,12 +35,12 @@
 @endif
 
 @if ( ($project->getUser() == \Auth::user() && \Auth::user()->can('project.printLabel.self')) || ($project->getUser() != \Auth::user() && \Auth::user()->can('project.printLabel.all')) )
-  @if (SiteVisitor::inTheSpace() && $project->getState() == \HMS\Entities\Members\Project::PROJCET_ACTIVE)
+  @if (SiteVisitor::inTheSpace() && $project->getState() == \HMS\Entities\Members\ProjectState::ACTIVE)
   <a href="{{ route('projects.print', $project->getId()) }}" class="button"><i class="fa fa-print fa-lg" aria-hidden="true"></i> Print Do-Not-Hack Label</a>
   @endif
 @endcan
 
-@if ($project->getState() == \HMS\Entities\Members\Project::PROJCET_ACTIVE)
+@if ($project->getState() == \HMS\Entities\Members\ProjectState::ACTIVE)
   @if ($project->getUser() == \Auth::user() && \Auth::user()->can('project.edit.self'))
   <a href="javascript:void(0);" onclick="$(this).find('form').submit();" class="button">
     <form action="{{ route('projects.markComplete', $project->getId()) }}" method="POST" style="display: none">
@@ -61,7 +61,7 @@
 @endif
 
 @if ( ($project->getUser() == \Auth::user() && \Auth::user()->can('project.printLabel.self')) || ($project->getUser() != \Auth::user() && \Auth::user()->can('project.printLabel.all')) )
-  @if ($project->getState() != \HMS\Entities\Members\Project::PROJCET_ACTIVE)
+  @if ($project->getState() != \HMS\Entities\Members\ProjectState::ACTIVE)
   <a href="javascript:void(0);" onclick="$(this).find('form').submit();" class="button">
     <form action="{{ route('projects.markActive', $project->getId()) }}" method="POST" style="display: none">
       {{ method_field('PATCH') }}


### PR DESCRIPTION
This is some refactoring to extract what are essentially enumerated types (which PHP doesn't support) into separate classes to avoid cluttering the domain entity classes. I have also removed the code duplication that was present in the `$statusStrings` which will prevent them from becoming out of sync with their numeric values.

So `Project::PROJECT_ACTIVE` is now simply `ProjectState::ACTIVE`