### PR TITLE
Stripe: new Event entity and webhook refactor

### DIFF
--- a/app/HMS/Entities/Banking/Stripe/Event.php
+++ b/app/HMS/Entities/Banking/Stripe/Event.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace HMS\Entities\Banking\Stripe;
+
+use HMS\Traits\Entities\Timestampable;
+
+class Event
+{
+    use Timestampable;
+
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @var null|Carbon
+     */
+    protected $handledAt;
+
+    /**
+     * Gets the value of id.
+     *
+     * @return int
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     *
+     * @return self
+     */
+    public function setId($id)
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    /**
+     * @return null|Carbon
+     */
+    public function getHandledAt()
+    {
+        return $this->handledAt;
+    }
+
+    /**
+     * @param null|Carbon $handledAt
+     *
+     * @return self
+     */
+    public function setHandledAt(?Carbon $handledAt)
+    {
+        $this->handledAt = $handledAt;
+
+        return $this;
+    }
+}

--- a/app/HMS/Entities/Banking/Stripe/Event.php
+++ b/app/HMS/Entities/Banking/Stripe/Event.php
@@ -2,6 +2,7 @@
 
 namespace HMS\Entities\Banking\Stripe;
 
+use Carbon\Carbon;
 use HMS\Traits\Entities\Timestampable;
 
 class Event

--- a/app/HMS/Mappings/HMS.Entities.Banking.Stripe.Charge.dcm.yml
+++ b/app/HMS/Mappings/HMS.Entities.Banking.Stripe.Charge.dcm.yml
@@ -1,7 +1,7 @@
 # HMS.Entities.Banking.Stripe.Charge.dcm.yml
 HMS\Entities\Banking\Stripe\Charge:
   type: entity
-  repositoryClass: HMS\Repositories\Banking\Doctrine\DoctrineChargeRepository
+  repositoryClass: HMS\Repositories\Banking\Stripe\Doctrine\DoctrineChargeRepository
   table: stripe_charges
   id:
     id:

--- a/app/HMS/Mappings/HMS.Entities.Banking.Stripe.Event.dcm.yml
+++ b/app/HMS/Mappings/HMS.Entities.Banking.Stripe.Event.dcm.yml
@@ -13,9 +13,6 @@ HMS\Entities\Banking\Stripe\Event:
     handledAt:
       type: datetime
       nullable: true
-      gedmo:
-        timestampable:
-          on: create
     createdAt:
       type: datetime
       gedmo:

--- a/app/HMS/Mappings/HMS.Entities.Banking.Stripe.Event.dcm.yml
+++ b/app/HMS/Mappings/HMS.Entities.Banking.Stripe.Event.dcm.yml
@@ -1,0 +1,28 @@
+# HMS.Entities.Banking.Stripe.Event.dcm.yml
+HMS\Entities\Banking\Stripe\Event:
+  type: entity
+  repositoryClass: HMS\Repositories\Banking\Stripe\Doctrine\DoctrineEventRepository
+  table: stripe_events
+  id:
+    id:
+      type: string
+      length: 140
+      generator:
+        strategy: NONE
+  fields:
+    handledAt:
+      type: datetime
+      nullable: true
+      gedmo:
+        timestampable:
+          on: create
+    createdAt:
+      type: datetime
+      gedmo:
+        timestampable:
+          on: create
+    updatedAt:
+      type: datetime
+      gedmo:
+        timestampable:
+          on: update

--- a/app/HMS/Repositories/Banking/Stripe/Doctrine/DoctrineEventRepository.php
+++ b/app/HMS/Repositories/Banking/Stripe/Doctrine/DoctrineEventRepository.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace HMS\Repositories\Banking\Stripe\Doctrine;
+
+use HMS\Entities\Banking\Stripe\Event;
+use Doctrine\ORM\EntityRepository;
+use HMS\Repositories\Banking\Stripe\EventRepository;
+
+class DoctrineEventRepository extends EntityRepository implements EventRepository
+{
+    /**
+     * Find a Event by id.
+     *
+     * @param string id
+     *
+     * @return null|Event
+     */
+    public function findOneById(string $id)
+    {
+        return parent::findOneById($id);
+    }
+
+    /**
+     * Save Event to the DB.
+     *
+     * @param Event $event
+     *
+     * @return Event
+     */
+    public function save(Event $event)
+    {
+        $this->_em->persist($event);
+        $this->_em->flush();
+
+        return $event;
+    }
+}

--- a/app/HMS/Repositories/Banking/Stripe/Doctrine/DoctrineEventRepository.php
+++ b/app/HMS/Repositories/Banking/Stripe/Doctrine/DoctrineEventRepository.php
@@ -2,8 +2,8 @@
 
 namespace HMS\Repositories\Banking\Stripe\Doctrine;
 
-use HMS\Entities\Banking\Stripe\Event;
 use Doctrine\ORM\EntityRepository;
+use HMS\Entities\Banking\Stripe\Event;
 use HMS\Repositories\Banking\Stripe\EventRepository;
 
 class DoctrineEventRepository extends EntityRepository implements EventRepository

--- a/app/HMS/Repositories/Banking/Stripe/EventRepository.php
+++ b/app/HMS/Repositories/Banking/Stripe/EventRepository.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace HMS\Repositories\Banking\Stripe;
+
+use HMS\Entities\Banking\Stripe\Event;
+
+interface EventRepository
+{
+    /**
+     * Find a Event by id.
+     *
+     * @param string id
+     *
+     * @return null|Event
+     */
+    public function findOneById(string $id);
+
+    /**
+     * Save Event to the DB.
+     *
+     * @param Event $event
+     *
+     * @return Event
+     */
+    public function save(Event $event);
+}

--- a/app/Jobs/Banking/Stripe/Webhooks/EventHandler.php
+++ b/app/Jobs/Banking/Stripe/Webhooks/EventHandler.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace App\Jobs\Banking\Stripe\Webhooks;
+
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Stripe\Event as StripeEvent;
+use HMS\Repositories\RoleRepository;
+use HMS\Repositories\UserRepository;
+use HMS\Entities\Banking\Stripe\Event;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Spatie\WebhookClient\Models\WebhookCall;
+use HMS\Factories\Banking\Stripe\ChargeFactory;
+use HMS\Factories\Snackspace\TransactionFactory;
+use HMS\Repositories\Banking\Stripe\EventRepository;
+use HMS\Repositories\Banking\Stripe\ChargeRepository;
+use HMS\Repositories\Snackspace\TransactionRepository;
+
+abstract class EventHandler implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * @var WebhookCall
+     */
+    protected $webhookCall;
+
+    /**
+     * @var StripeEvent
+     */
+    protected $stripeEvent;
+
+    /**
+     * @var UserRepository
+     */
+    protected $userRepository;
+
+    /**
+     * @var ChargeRepository
+     */
+    protected $chargeRepository;
+
+    /**
+     * @var EventRepository
+     */
+    protected $eventRepository;
+
+    /**
+     * @var TransactionFactory
+     */
+    protected $transactionFactory;
+
+    /**
+     * @var TransactionRepository
+     */
+    protected $transactionRepository;
+
+    /**
+     * @var RoleRepository
+     */
+    protected $roleRepository;
+
+    /**
+     * Create a new job instance.
+     *
+     * @param WebhookCall $webhookCall
+     *
+     * @return void
+     */
+    public function __construct(WebhookCall $webhookCall)
+    {
+        $this->webhookCall = $webhookCall;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @param UserRepository $userRepository
+     * @param ChargeFactory $chargeFactory
+     * @param ChargeRepository $chargeRepository
+     * @param EventRepository $eventRepository
+     * @param TransactionFactory $transactionFactory
+     * @param TransactionRepository $transactionRepository
+     * @param RoleRepository $roleRepository
+     *
+     * @return void
+     */
+    public function handle(
+        UserRepository $userRepository,
+        ChargeFactory $chargeFactory,
+        ChargeRepository $chargeRepository,
+        EventRepository $eventRepository,
+        TransactionFactory $transactionFactory,
+        TransactionRepository $transactionRepository,
+        RoleRepository $roleRepository
+    ) {
+        $this->userRepository = $userRepository;
+        $this->chargeRepository = $chargeRepository;
+        $this->transactionFactory = $transactionFactory;
+        $this->transactionRepository = $transactionRepository;
+        $this->roleRepository = $roleRepository;
+
+        $this->stripeEvent = StripeEvent::constructFrom($this->webhookCall->payload);
+
+        // in order to not reprocess an event multiple times we log it to the db
+        $event = $eventRepository->findOneById($this->stripeEvent->id);
+
+        if (! is_null($event)) {
+            if (! is_null($event->getHandledAt())) {
+                // this stripeEvent id has already been handled before
+                // we should get out now
+                \Log::info(
+                    'Stripe Event ' . $this->stripeEvent->id .
+                    ' already handled at ' . $event->getHandledAt()->toDateTimeString()
+                );
+
+                return;
+            }
+            // event is in the db but not handled yet, must have failed before :/
+        } else {
+            // not seen this stripeEvent id before
+            $event = new Event();
+            $event->setId($this->stripeEvent->id);
+            $event = $eventRepository->save($event);
+        }
+
+        // deal with this parenthetical stripeEvent as needed
+        $complete = $this->run();
+
+        if ($complete) {
+            // Log this event as now being handled
+            // we will not get here if run returns false or an exception was thrown
+            $event->setHandledAt(Carbon::now());
+            $eventRepository->save($event);
+        }
+    }
+
+    /**
+     * Handle this event.
+     *
+     * @return bool Is this event handling complete.
+     */
+    abstract protected function run();
+}

--- a/app/Jobs/Banking/Stripe/Webhooks/HandleChargeDisputeClosedJob.php
+++ b/app/Jobs/Banking/Stripe/Webhooks/HandleChargeDisputeClosedJob.php
@@ -2,50 +2,20 @@
 
 namespace App\Jobs\Banking\Stripe\Webhooks;
 
-use Stripe\Event;
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Spatie\WebhookClient\Models\WebhookCall;
-use HMS\Repositories\Banking\Stripe\ChargeRepository;
-
-class HandleChargeDisputeClosedJob implements ShouldQueue
+class HandleChargeDisputeClosedJob extends EventHandler
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
     /**
-     * @var WebhookCall
-     */
-    protected $webhookCall;
-
-    /**
-     * Create a new job instance.
+     * Handle this event.
      *
-     * @param WebhookCall $webhookCall
-     *
-     * @return void
+     * @return bool Is this event handling complete.
      */
-    public function __construct(WebhookCall $webhookCall)
+    protected function run()
     {
-        $this->webhookCall = $webhookCall;
-    }
-
-    /**
-     * Execute the job.
-     *
-     * @param ChargeRepository $chargeRepository
-     *
-     * @return void
-     */
-    public function handle(
-        ChargeRepository $chargeRepository
-    ) {
-        // We don't yet have any real need for this hook so just log it out for now
-        $event = Event::constructFrom($this->webhookCall->payload);
-        $stripDispute = $event->data->object;
+        // We don't yet have any real need for this event so just log it out for now
+        $stripDispute = $this->stripeEvent->data->object;
         \Log::info('HandleChargeDisputeClosedJob');
         \Log::info($stripDispute);
+
+        return true;
     }
 }

--- a/app/Jobs/Banking/Stripe/Webhooks/HandleChargeDisputeCreatedJob.php
+++ b/app/Jobs/Banking/Stripe/Webhooks/HandleChargeDisputeCreatedJob.php
@@ -2,78 +2,47 @@
 
 namespace App\Jobs\Banking\Stripe\Webhooks;
 
-use Stripe\Event;
 use HMS\Entities\Role;
-use Illuminate\Bus\Queueable;
-use HMS\Repositories\RoleRepository;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Spatie\WebhookClient\Models\WebhookCall;
 use App\Notifications\Banking\Stripe\DisputeCreated;
-use HMS\Repositories\Banking\Stripe\ChargeRepository;
+use App\Notifications\Banking\Stripe\ProcessingIssue;
 
-class HandleChargeDisputeCreatedJob implements ShouldQueue
+class HandleChargeDisputeCreatedJob extends EventHandler
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
     /**
-     * @var WebhookCall
-     */
-    protected $webhookCall;
-
-    /**
-     * Create a new job instance.
+     * Handle this event.
      *
-     * @param WebhookCall $webhookCall
-     *
-     * @return void
+     * @return bool Is this event handling complete.
      */
-    public function __construct(WebhookCall $webhookCall)
+    protected function run()
     {
-        $this->webhookCall = $webhookCall;
-    }
-
-    /**
-     * Execute the job.
-     *
-     * @param ChargeRepository $chargeRepository
-     * @param RoleRepository $roleRepository
-     *
-     * @return void
-     */
-    public function handle(
-        ChargeRepository $chargeRepository,
-        RoleRepository $roleRepository
-    ) {
-        $event = Event::constructFrom($this->webhookCall->payload);
-        $stripeDispute = $event->data->object;
+        $stripeDispute = $this->stripeEvent->data->object;
         $chargeId = $stripeDispute->charge;
 
         // find charge
-        $charge = $chargeRepository->findOneById($chargeId);
+        $charge = $this->chargeRepository->findOneById($chargeId);
 
         if (is_null($charge)) {
             // TODO: bugger should we create one?
             // for now log it and tell software team
             \Log::error('HandleChargeRefundedJob: Charge not found');
-            $softwareTeamRole = $roleRepository->findOneByName(ROLE::SOFTWARE_TEAM);
+            $softwareTeamRole = $this->roleRepository->findOneByName(Role::SOFTWARE_TEAM);
             $softwareTeamRole->notify(new ProcessingIssue($this->webhookCall, 'Dispute Created'));
 
-            return;
+            return true;
         }
 
         $charge->setDisputeId($stripeDispute->id);
-        $charge = $chargeRepository->save($charge);
+        $charge = $this->chargeRepository->save($charge);
 
         $disputeCreatedNotification = new DisputeCreated($charge, $stripeDispute);
 
         // notify TEAM_TRUSTEES TEAM_FINANCE
-        $financeTeamRole = $roleRepository->findOneByName(Role::TEAM_FINANCE);
+        $financeTeamRole = $this->roleRepository->findOneByName(Role::TEAM_FINANCE);
         $financeTeamRole->notify($disputeCreatedNotification);
 
-        $trusteesTeamRole = $roleRepository->findOneByName(Role::TEAM_TRUSTEES);
+        $trusteesTeamRole = $this->roleRepository->findOneByName(Role::TEAM_TRUSTEES);
         $trusteesTeamRole->notify($disputeCreatedNotification);
+
+        return true;
     }
 }

--- a/app/Jobs/Banking/Stripe/Webhooks/HandleChargeDisputeFundsWithdrawnJob.php
+++ b/app/Jobs/Banking/Stripe/Webhooks/HandleChargeDisputeFundsWithdrawnJob.php
@@ -2,73 +2,33 @@
 
 namespace App\Jobs\Banking\Stripe\Webhooks;
 
-use Stripe\Event;
 use HMS\Entities\Role;
-use Illuminate\Bus\Queueable;
-use HMS\Repositories\RoleRepository;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
 use HMS\Entities\Banking\Stripe\ChargeType;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
 use HMS\Entities\Snackspace\TransactionType;
-use Spatie\WebhookClient\Models\WebhookCall;
-use HMS\Factories\Snackspace\TransactionFactory;
 use App\Notifications\Banking\Stripe\ProcessingIssue;
-use HMS\Repositories\Banking\Stripe\ChargeRepository;
-use HMS\Repositories\Snackspace\TransactionRepository;
 use App\Notifications\Banking\Stripe\DisputeDonationFundsWithdrawn;
 use App\Notifications\Banking\Stripe\DisputeSnackspaceFundsWithdrawn;
 
-class HandleChargeDisputeFundsWithdrawnJob implements ShouldQueue
+class HandleChargeDisputeFundsWithdrawnJob extends EventHandler
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
     /**
-     * @var WebhookCall
-     */
-    protected $webhookCall;
-
-    /**
-     * Create a new job instance.
+     * Handle this event.
      *
-     * @param WebhookCall $webhookCall
-     *
-     * @return void
+     * @return bool Is this event handling complete.
      */
-    public function __construct(WebhookCall $webhookCall)
+    protected function run()
     {
-        $this->webhookCall = $webhookCall;
-    }
-
-    /**
-     * Execute the job.
-     *
-     * @param ChargeRepository $chargeRepository
-     * @param TransactionFactory $transactionFactory
-     * @param TransactionRepository $transactionRepository
-     * @param RoleRepository $roleRepository
-     *
-     * @return void
-     */
-    public function handle(
-        ChargeRepository $chargeRepository,
-        TransactionFactory $transactionFactory,
-        TransactionRepository $transactionRepository,
-        RoleRepository $roleRepository
-    ) {
-        $event = Event::constructFrom($this->webhookCall->payload);
-        $stripeDispute = $event->data->object;
+        $stripeDispute = $this->stripeEvent->data->object;
         $chargeId = $stripeDispute->charge;
 
         // find charge
-        $charge = $chargeRepository->findOneById($chargeId);
+        $charge = $this->chargeRepository->findOneById($chargeId);
 
         if (is_null($charge)) {
             // TODO: bugger should we create one?
             // for now log it and tell software team
             \Log::error('HandleChargeRefundedJob: Charge not found');
-            $softwareTeamRole = $roleRepository->findOneByName(ROLE::SOFTWARE_TEAM);
+            $softwareTeamRole = $this->roleRepository->findOneByName(Role::SOFTWARE_TEAM);
             $softwareTeamRole->notify(new ProcessingIssue($this->webhookCall, 'Dispute Funds Withdrawn'));
 
             return;
@@ -81,17 +41,17 @@ class HandleChargeDisputeFundsWithdrawnJob implements ShouldQueue
             $stringAmount = money_format('%n', $amount / 100);
             $description = 'Dispute online card payment (funds withdrawn) : ' . $stringAmount;
 
-            $transaction = $transactionFactory->create(
+            $transaction = $this->transactionFactory->create(
                 $charge->getUser(),
                 $amount,
                 TransactionType::ONLINE_PAYMENT,
                 $description
             );
 
-            $transaction = $transactionRepository->saveAndUpdateBalance($transaction);
+            $transaction = $this->transactionRepository->saveAndUpdateBalance($transaction);
 
             $charge->setWithdrawnTransaction($transaction);
-            $charge = $chargeRepository->save($charge);
+            $charge = $this->chargeRepository->save($charge);
 
             $disputeSnackspaceFundsWithdrawnNotification = new DisputeSnackspaceFundsWithdrawn($charge, $stripeDispute);
 
@@ -100,19 +60,19 @@ class HandleChargeDisputeFundsWithdrawnJob implements ShouldQueue
             $charge->getUser()->notify($disputeSnackspaceFundsWithdrawnNotification);
 
             // notify TEAM_TRUSTEES TEAM_FINANCE
-            $financeTeamRole = $roleRepository->findOneByName(Role::TEAM_FINANCE);
+            $financeTeamRole = $this->roleRepository->findOneByName(Role::TEAM_FINANCE);
             $financeTeamRole->notify($disputeSnackspaceFundsWithdrawnNotification);
 
-            $trusteesTeamRole = $roleRepository->findOneByName(Role::TEAM_TRUSTEES);
+            $trusteesTeamRole = $this->roleRepository->findOneByName(Role::TEAM_TRUSTEES);
             $trusteesTeamRole->notify($disputeSnackspaceFundsWithdrawnNotification);
         } else {
             $disputeDonationFundsWithdrawnNotification = new DisputeDonationFundsWithdrawn($charge, $stripeDispute);
 
             // notify TEAM_TRUSTEES TEAM_FINANCE
-            $financeTeamRole = $roleRepository->findOneByName(Role::TEAM_FINANCE);
+            $financeTeamRole = $this->roleRepository->findOneByName(Role::TEAM_FINANCE);
             $financeTeamRole->notify($disputeDonationFundsWithdrawnNotification);
 
-            $trusteesTeamRole = $roleRepository->findOneByName(Role::TEAM_TRUSTEES);
+            $trusteesTeamRole = $this->roleRepository->findOneByName(Role::TEAM_TRUSTEES);
             $trusteesTeamRole->notify($disputeDonationFundsWithdrawnNotification);
         }
     }

--- a/app/Jobs/Banking/Stripe/Webhooks/HandleChargeDisputeUpdatedJob.php
+++ b/app/Jobs/Banking/Stripe/Webhooks/HandleChargeDisputeUpdatedJob.php
@@ -2,50 +2,20 @@
 
 namespace App\Jobs\Banking\Stripe\Webhooks;
 
-use Stripe\Event;
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Spatie\WebhookClient\Models\WebhookCall;
-use HMS\Repositories\Banking\Stripe\ChargeRepository;
-
-class HandleChargeDisputeUpdatedJob implements ShouldQueue
+class HandleChargeDisputeUpdatedJob extends EventHandler
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
     /**
-     * @var WebhookCall
-     */
-    protected $webhookCall;
-
-    /**
-     * Create a new job instance.
+     * Handle this event.
      *
-     * @param WebhookCall $webhookCall
-     *
-     * @return void
+     * @return bool Is this event handling complete.
      */
-    public function __construct(WebhookCall $webhookCall)
+    protected function run()
     {
-        $this->webhookCall = $webhookCall;
-    }
-
-    /**
-     * Execute the job.
-     *
-     * @param ChargeRepository $chargeRepository
-     *
-     * @return void
-     */
-    public function handle(
-        ChargeRepository $chargeRepository
-    ) {
         // We don't yet have any real need for this event so just log it out for now
-        $event = Event::constructFrom($this->webhookCall->payload);
-        $stripeDispute = $event->data->object;
+        $stripeDispute = $this->stripeEvent->data->object;
         \Log::info('HandleChargeDisputeUpdatedJob');
         \Log::info($stripeDispute);
+
+        return true;
     }
 }

--- a/app/Jobs/Banking/Stripe/Webhooks/HandleChargeRefundUpdatedJob.php
+++ b/app/Jobs/Banking/Stripe/Webhooks/HandleChargeRefundUpdatedJob.php
@@ -2,50 +2,20 @@
 
 namespace App\Jobs\Banking\Stripe\Webhooks;
 
-use Stripe\Event;
-use Illuminate\Bus\Queueable;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
-use Spatie\WebhookClient\Models\WebhookCall;
-use HMS\Repositories\Banking\Stripe\ChargeRepository;
-
-class HandleChargeRefundUpdatedJob implements ShouldQueue
+class HandleChargeRefundUpdatedJob extends EventHandler
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
     /**
-     * @var WebhookCall
-     */
-    protected $webhookCall;
-
-    /**
-     * Create a new job instance.
+     * Handle this event.
      *
-     * @param WebhookCall $webhookCall
-     *
-     * @return void
+     * @return bool Is this event handling complete.
      */
-    public function __construct(WebhookCall $webhookCall)
+    protected function run()
     {
-        $this->webhookCall = $webhookCall;
-    }
-
-    /**
-     * Execute the job.
-     *
-     * @param ChargeRepository $chargeRepository
-     *
-     * @return void
-     */
-    public function handle(
-        ChargeRepository $chargeRepository
-    ) {
-        // We don't yet have any real need for this hook so just log it out for now
-        $event = Event::constructFrom($this->webhookCall->payload);
-        $stripeRefund = $event->data->object;
+        // We don't yet have any real need for this event so just log it out for now
+        $stripeRefund = $this->event->data->object;
         \Log::info('HandleChargeRefundUpdatedJob');
         \Log::info($stripeRefund);
+
+        return true;
     }
 }

--- a/app/Jobs/Banking/Stripe/Webhooks/HandleChargeRefundedJob.php
+++ b/app/Jobs/Banking/Stripe/Webhooks/HandleChargeRefundedJob.php
@@ -2,107 +2,43 @@
 
 namespace App\Jobs\Banking\Stripe\Webhooks;
 
-use Stripe\Event;
 use HMS\Entities\Role;
-use Illuminate\Bus\Queueable;
 use Stripe\Charge as StripeCharge;
-use HMS\Repositories\RoleRepository;
-use Illuminate\Queue\SerializesModels;
 use HMS\Entities\Banking\Stripe\Charge;
-use Illuminate\Queue\InteractsWithQueue;
 use HMS\Entities\Banking\Stripe\ChargeType;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
 use HMS\Entities\Snackspace\TransactionType;
-use Spatie\WebhookClient\Models\WebhookCall;
-use HMS\Factories\Snackspace\TransactionFactory;
 use App\Notifications\Banking\Stripe\DonationRefund;
 use App\Notifications\Banking\Stripe\ProcessingIssue;
-use HMS\Repositories\Banking\Stripe\ChargeRepository;
 use App\Notifications\Banking\Stripe\SnackspaceRefund;
-use HMS\Repositories\Snackspace\TransactionRepository;
 
-class HandleChargeRefundedJob implements ShouldQueue
+class HandleChargeRefundedJob extends EventHandler
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
     /**
-     * @var WebhookCall
-     */
-    protected $webhookCall;
-
-    /**
-     * @var UserRepository
-     */
-    protected $userRepository;
-
-    /**
-     * @var TransactionFactory
-     */
-    protected $transactionFactory;
-
-    /**
-     * @var TransactionRepository
-     */
-    protected $transactionRepository;
-
-    /**
-     * @var RoleRepository
-     */
-    protected $roleRepository;
-
-    /**
-     * Create a new job instance.
+     * Handle this event.
      *
-     * @param WebhookCall $webhookCall
-     *
-     * @return void
+     * @return bool Is this event handling complete.
      */
-    public function __construct(WebhookCall $webhookCall)
+    protected function run()
     {
-        $this->webhookCall = $webhookCall;
-    }
-
-    /**
-     * Execute the job.
-     *
-     * @param ChargeRepository $chargeRepository
-     * @param TransactionRepository $transactionRepository
-     * @param RoleRepository $roleRepository
-     *
-     * @return void
-     */
-    public function handle(
-        ChargeRepository $chargeRepository,
-        TransactionFactory $transactionFactory,
-        TransactionRepository $transactionRepository,
-        RoleRepository $roleRepository
-    ) {
-        $this->chargeRepository = $chargeRepository;
-        $this->transactionFactory = $transactionFactory;
-        $this->transactionRepository = $transactionRepository;
-        $this->roleRepository = $roleRepository;
-
-        $event = Event::constructFrom($this->webhookCall->payload);
-        $stripeCharge = $event->data->object;
+        $stripeCharge = $this->stripeEvent->data->object;
 
         if (! $stripeCharge->refunded) {
             // should not be here
             \Log::error('HandleChargeRefundedJob: not refunded? :/');
 
-            return;
+            return true;
         }
 
-        $charge = $chargeRepository->findOneById($stripeCharge->id);
+        $charge = $this->chargeRepository->findOneById($stripeCharge->id);
 
         if (is_null($charge)) {
             // TODO: bugger should we create one?
             // for now log it and tell software team
             \Log::error('HandleChargeRefundedJob: Charge not found');
-            $softwareTeamRole = $roleRepository->findOneByName(ROLE::SOFTWARE_TEAM);
+            $softwareTeamRole = $this->roleRepository->findOneByName(Role::SOFTWARE_TEAM);
             $softwareTeamRole->notify(new ProcessingIssue($this->webhookCall, 'Charge Refunded'));
 
-            return;
+            return true;
         }
 
         $charge->setRefundId($stripeCharge->refunds->data[0]->id);
@@ -110,17 +46,20 @@ class HandleChargeRefundedJob implements ShouldQueue
 
         switch ($charge->getType()) {
             case ChargeType::SNACKSPACE:
-                $this->snackspacePayment($stripeCharge, $charge);
+                $ret = $this->snackspacePayment($stripeCharge, $charge);
                 break;
 
             case ChargeType::DONATION:
-                $this->donationPayment($stripeCharge, $charge);
+                $ret = $this->donationPayment($stripeCharge, $charge);
                 break;
 
             default:
                 \Log::warning('HandleChargeRefundedJob: UnknownChargeType');
+                $ret = true;
                 break;
         }
+
+        return $ret;
     }
 
     /**
@@ -129,7 +68,7 @@ class HandleChargeRefundedJob implements ShouldQueue
      * @param StripeCharge $stripeCharge Stripe/Charge instance
      * @param Charge $chargen Our Banking instance
      */
-    public function snackspacePayment(StripeCharge $stripeCharge, Charge $charge)
+    protected function snackspacePayment(StripeCharge $stripeCharge, Charge $charge)
     {
         $user = $charge->getUser();
 
@@ -160,6 +99,8 @@ class HandleChargeRefundedJob implements ShouldQueue
 
         $trusteesTeamRole = $this->roleRepository->findOneByName(Role::TEAM_TRUSTEES);
         $trusteesTeamRole->notify($snackspaceRefundNotification);
+
+        return true;
     }
 
     /**
@@ -168,7 +109,7 @@ class HandleChargeRefundedJob implements ShouldQueue
      * @param StripeCharge $stripeCharge Stripe/Charge instance
      * @param Charge $chargen Our Banking instance
      */
-    public function donationPayment(StripeCharge $stripeCharge, Charge $charge)
+    protected function donationPayment(StripeCharge $stripeCharge, Charge $charge)
     {
         $user = $charge->getUser();
         // negate the amount
@@ -187,5 +128,7 @@ class HandleChargeRefundedJob implements ShouldQueue
 
         $trusteesTeamRole = $this->roleRepository->findOneByName(Role::TEAM_TRUSTEES);
         $trusteesTeamRole->notify($donationRefundNotification);
+
+        return true;
     }
 }

--- a/app/Jobs/Banking/Stripe/Webhooks/HandleChargeSucceededJob.php
+++ b/app/Jobs/Banking/Stripe/Webhooks/HandleChargeSucceededJob.php
@@ -2,118 +2,45 @@
 
 namespace App\Jobs\Banking\Stripe\Webhooks;
 
-use Stripe\Event;
 use HMS\Entities\Role;
-use Illuminate\Bus\Queueable;
 use Stripe\Charge as StripeCharge;
-use HMS\Repositories\RoleRepository;
-use HMS\Repositories\UserRepository;
-use Illuminate\Queue\SerializesModels;
 use HMS\Entities\Banking\Stripe\Charge;
-use Illuminate\Queue\InteractsWithQueue;
 use HMS\Entities\Banking\Stripe\ChargeType;
-use Illuminate\Contracts\Queue\ShouldQueue;
-use Illuminate\Foundation\Bus\Dispatchable;
 use HMS\Entities\Snackspace\TransactionType;
-use Spatie\WebhookClient\Models\WebhookCall;
-use HMS\Factories\Banking\Stripe\ChargeFactory;
-use HMS\Factories\Snackspace\TransactionFactory;
 use App\Notifications\Banking\Stripe\DonationPayment;
-use HMS\Repositories\Banking\Stripe\ChargeRepository;
-use HMS\Repositories\Snackspace\TransactionRepository;
 use App\Notifications\Banking\Stripe\SnackspacePayment;
 
-class HandleChargeSucceededJob implements ShouldQueue
+class HandleChargeSucceededJob extends EventHandler
 {
-    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
-
     /**
-     * @var WebhookCall
-     */
-    protected $webhookCall;
-
-    /**
-     * @var UserRepository
-     */
-    protected $userRepository;
-
-    /**
-     * @var ChargeRepository
-     */
-    protected $chargeRepository;
-
-    /**
-     * @var TransactionFactory
-     */
-    protected $transactionFactory;
-
-    /**
-     * @var TransactionRepository
-     */
-    protected $transactionRepository;
-
-    /**
-     * @var RoleRepository
-     */
-    protected $roleRepository;
-
-    /**
-     * Create a new job instance.
+     * Handle this event.
      *
-     * @param WebhookCall $webhookCall
-     *
-     * @return void
+     * @return bool Is this event handling complete.
      */
-    public function __construct(WebhookCall $webhookCall)
+    protected function run()
     {
-        $this->webhookCall = $webhookCall;
-    }
-
-    /**
-     * Execute the job.
-     *
-     * @param UserRepository $userRepository
-     * @param ChargeFactory $chargeFactory
-     * @param ChargeRepository $chargeRepository
-     * @param TransactionFactory $transactionFactory
-     * @param TransactionRepository $transactionRepository
-     * @param RoleRepository $roleRepository
-     *
-     * @return void
-     */
-    public function handle(
-        UserRepository $userRepository,
-        ChargeFactory $chargeFactory,
-        ChargeRepository $chargeRepository,
-        TransactionFactory $transactionFactory,
-        TransactionRepository $transactionRepository,
-        RoleRepository $roleRepository
-    ) {
-        $this->userRepository = $userRepository;
-        $this->chargeRepository = $chargeRepository;
-        $this->transactionFactory = $transactionFactory;
-        $this->transactionRepository = $transactionRepository;
-        $this->roleRepository = $roleRepository;
-
-        $event = Event::constructFrom($this->webhookCall->payload);
-        $stripeCharge = $event->data->object;
+        $stripeCharge = $this->stripeEvent->data->object;
         $type = strtoupper($stripeCharge->metadata->type);
 
-        $charge = $chargeFactory->create($stripeCharge->id, $stripeCharge->amount, $type);
+        $charge = $this->chargeFactory->create($stripeCharge->id, $stripeCharge->amount, $type);
         $this->chargeRepository->save($charge);
 
         switch ($type) {
             case ChargeType::SNACKSPACE:
-                $this->snackspacePayment($stripeCharge, $charge);
+                $ret = $this->snackspacePayment($stripeCharge, $charge);
                 break;
 
             case ChargeType::DONATION:
-                $this->donationPayment($stripeCharge, $charge);
+                $ret = $this->donationPayment($stripeCharge, $charge);
                 break;
 
             default:
+                \Log::warning('HandleChargeSucceededJob: UnknownChargeType');
+                $ret = true;
                 break;
         }
+
+        return $ret;
     }
 
     /**
@@ -121,8 +48,10 @@ class HandleChargeSucceededJob implements ShouldQueue
      *
      * @param StripeCharge $stripeCharge Stripe/Charge instance
      * @param Charge $chargen Our Banking instance
+     *
+     * @return bool
      */
-    public function snackspacePayment(StripeCharge $stripeCharge, Charge $charge)
+    protected function snackspacePayment(StripeCharge $stripeCharge, Charge $charge)
     {
         $userId = $stripeCharge->metadata->user_id;
         $user = $this->userRepository->findOneById($userId);
@@ -143,6 +72,8 @@ class HandleChargeSucceededJob implements ShouldQueue
 
         // notify User
         $user->notify(new SnackspacePayment($charge));
+
+        return true;
     }
 
     /**
@@ -150,8 +81,10 @@ class HandleChargeSucceededJob implements ShouldQueue
      *
      * @param StripeCharge $stripeCharge Stripe/Charge instance
      * @param Charge $chargen Our Banking instance
+     *
+     * @return bool
      */
-    public function donationPayment(StripeCharge $stripeCharge, Charge $charge)
+    protected function donationPayment(StripeCharge $stripeCharge, Charge $charge)
     {
         $userId = $stripeCharge->metadata->user_id;
         $user = $this->userRepository->findOneById($userId);
@@ -171,5 +104,7 @@ class HandleChargeSucceededJob implements ShouldQueue
 
         $trusteesTeamRole = $this->roleRepository->findOneByName(Role::TEAM_TRUSTEES);
         $trusteesTeamRole->notify($donationPaymentNotification);
+
+        return true;
     }
 }

--- a/config/repositories.php
+++ b/config/repositories.php
@@ -54,6 +54,7 @@ return [
         'Banking\BankTransaction',
         'Banking\MembershipStatusNotification',
         'Banking\Stripe\Charge',
+        'Banking\Stripe\Event',
         'Members\Project',
         'Members\Box',
         'Snackspace\Debt',

--- a/database/migrations_doctrine/Version20190815051316_add_stripe_events_table.php
+++ b/database/migrations_doctrine/Version20190815051316_add_stripe_events_table.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Migrations;
+
+use Doctrine\DBAL\Schema\Schema as Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+class Version20190815051316_add_stripe_events_table extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE TABLE stripe_events (id VARCHAR(140) NOT NULL, handled_at DATETIME DEFAULT NULL, created_at DATETIME NOT NULL, updated_at DATETIME NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema)
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP TABLE stripe_events');
+    }
+}


### PR DESCRIPTION
add a new Event entity to track when webhook handling is completed
refactor all the Webhook Handler jobs adding some abstraction to cut down code reuse and use the new Event tracking
this should help prevent duplicate event handling by making your event processing idempotent