### PR TITLE
Fix for 15px horizontal scrollbar

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -46,7 +46,7 @@
   <!-- main body -->
   <main id="app" class="flex-fill my-3">
 @include('partials.flash')
-    <div class="row">
+    <div class="row mr-0">
       <div class="col-sm-12">
 @yield('content')
       </div>


### PR DESCRIPTION
Tested on mobile and desktop.

Prevents the 15px horizontal scrollbar from appearing. Since the
horizontal scrollbar was altering the height of the page very
slightly, some text fields would cause the page to jump about while
typing (e.g. on the login page).

The change overloads the .row horizontal margin from bootstrap and
adds some negative margin to the navbar.