### PR TITLE
Provide members with gatekeeper pin in setup email

### DIFF
--- a/app/Listeners/Membership/ApproveNewMembership.php
+++ b/app/Listeners/Membership/ApproveNewMembership.php
@@ -106,6 +106,7 @@ class ApproveNewMembership implements ShouldQueue
         if (count($this->pinRepository->findByUser($user)) == 0) {
             $pin = $this->pinFactory->createNewEnrollPinForUser($user);
             $this->pinRepository->save($pin);
+            $user->pin = $pin; // ensure pin is up to date for MembershipComplete email
         }
 
         // update join date

--- a/app/Listeners/Membership/ApproveNewMembership.php
+++ b/app/Listeners/Membership/ApproveNewMembership.php
@@ -113,6 +113,6 @@ class ApproveNewMembership implements ShouldQueue
         $this->userRepository->save($user);
 
         // email user
-        \Mail::to($user)->send(new MembershipComplete($user, $this->metaRepository, $this->roleRepository));
+        \Mail::to($user)->send(new MembershipComplete($user, $this->metaRepository, $this->roleRepository, $this->userRepository));
     }
 }

--- a/app/Listeners/Membership/ApproveNewMembership.php
+++ b/app/Listeners/Membership/ApproveNewMembership.php
@@ -106,7 +106,6 @@ class ApproveNewMembership implements ShouldQueue
         if (count($this->pinRepository->findByUser($user)) == 0) {
             $pin = $this->pinFactory->createNewEnrollPinForUser($user);
             $this->pinRepository->save($pin);
-            $user->pin = $pin; // ensure pin is up to date for MembershipComplete email
         }
 
         // update join date

--- a/app/Mail/Membership/MembershipComplete.php
+++ b/app/Mail/Membership/MembershipComplete.php
@@ -23,6 +23,11 @@ class MembershipComplete extends Mailable implements ShouldQueue
     /**
      * @var string
      */
+    public $membershipPIN;
+
+    /**
+     * @var string
+     */
     public $membersGuideHTML;
 
     /**
@@ -75,6 +80,13 @@ class MembershipComplete extends Mailable implements ShouldQueue
      */
     public $membershipTeamEmail;
 
+    /*
+     * @var string
+     */
+    public $gatekeeperSetupGuide;
+
+
+
     /**
      * Create a new message instance.
      *
@@ -85,6 +97,7 @@ class MembershipComplete extends Mailable implements ShouldQueue
     public function __construct(User $user, MetaRepository $metaRepository, RoleRepository $roleRepository)
     {
         $this->fullname = $user->getFullname();
+        $this->membershipPIN = $user->getPin()->getPin();
 
         $this->membersGuideHTML = $metaRepository->get('members_guide_html');
         $this->membersGuidePDF = $metaRepository->get('members_guide_pdf');
@@ -96,6 +109,7 @@ class MembershipComplete extends Mailable implements ShouldQueue
         $this->rulesHTML = $metaRepository->get('rules_html');
         $this->slackHTML = $metaRepository->get('slack_html');
         $this->wikiLink = $metaRepository->get('wiki_html');
+        $this->gatekeeperSetupGuide = $metaRepository->get('gatekeeper_setup_guide');
 
         $this->membershipTeamEmail = $roleRepository->findOneByName(Role::TEAM_MEMBERSHIP)->getEmail();
     }

--- a/app/Mail/Membership/MembershipComplete.php
+++ b/app/Mail/Membership/MembershipComplete.php
@@ -94,6 +94,9 @@ class MembershipComplete extends Mailable implements ShouldQueue
      */
     public function __construct(User $user, MetaRepository $metaRepository, RoleRepository $roleRepository)
     {
+        // get a fresh copy of the user
+        $user = $this->userRepository->findOneById($user->getId());
+
         $this->fullname = $user->getFullname();
         $this->membershipPIN = $user->getPin()->getPin();
 

--- a/app/Mail/Membership/MembershipComplete.php
+++ b/app/Mail/Membership/MembershipComplete.php
@@ -6,6 +6,7 @@ use HMS\Entities\Role;
 use HMS\Entities\User;
 use HMS\Repositories\MetaRepository;
 use HMS\Repositories\RoleRepository;
+use HMS\Repositories\UserRepository;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
@@ -16,8 +17,8 @@ class MembershipComplete extends Mailable implements ShouldQueue
     use Queueable, SerializesModels;
 
     /*
-    * @var string
-    */
+     * @var string
+     */
     public $fullname;
 
     /**
@@ -91,11 +92,12 @@ class MembershipComplete extends Mailable implements ShouldQueue
      * @param User $user
      * @param MetaRepository $metaRepository
      * @param RoleRepository $roleRepository
+     * @param UserRepository $userRepository
      */
-    public function __construct(User $user, MetaRepository $metaRepository, RoleRepository $roleRepository)
+    public function __construct(User $user, MetaRepository $metaRepository, RoleRepository $roleRepository, UserRepository $userRepository)
     {
         // get a fresh copy of the user
-        $user = $this->userRepository->findOneById($user->getId());
+        $user = $userRepository->findOneById($user->getId());
 
         $this->fullname = $user->getFullname();
         $this->membershipPin = $user->getPin()->getPin();

--- a/app/Mail/Membership/MembershipComplete.php
+++ b/app/Mail/Membership/MembershipComplete.php
@@ -85,8 +85,6 @@ class MembershipComplete extends Mailable implements ShouldQueue
      */
     public $gatekeeperSetupGuide;
 
-
-
     /**
      * Create a new message instance.
      *

--- a/app/Mail/Membership/MembershipComplete.php
+++ b/app/Mail/Membership/MembershipComplete.php
@@ -23,7 +23,7 @@ class MembershipComplete extends Mailable implements ShouldQueue
     /**
      * @var string
      */
-    public $membershipPIN;
+    public $membershipPin;
 
     /**
      * @var string
@@ -98,7 +98,7 @@ class MembershipComplete extends Mailable implements ShouldQueue
         $user = $this->userRepository->findOneById($user->getId());
 
         $this->fullname = $user->getFullname();
-        $this->membershipPIN = $user->getPin()->getPin();
+        $this->membershipPin = $user->getPin()->getPin();
 
         $this->membersGuideHTML = $metaRepository->get('members_guide_html');
         $this->membersGuidePDF = $metaRepository->get('members_guide_pdf');

--- a/config/meta.php
+++ b/config/meta.php
@@ -49,5 +49,6 @@ return [
         'temporary_access_uesr_notification' => 30,
         'wiki_html' => 'https://wiki.nottinghack.org.uk',
         'zone_occupant_reset_interval' => 'P1D',
+        'gatekeeper_setup_guide' => 'https://wiki.nottinghack.org.uk/wiki/HMS/Gatekeeper_Setup',
     ],
 ];

--- a/config/roles.php
+++ b/config/roles.php
@@ -75,7 +75,7 @@ return [
         'rfidTags.edit.all',
         'rfidTags.destroy',
         'pins.view.all',
-        'pins.view.own',
+        'pins.view.self',
         'pins.reactivate',
         'login.shell',
         'login.spacenet',
@@ -255,7 +255,7 @@ return [
                 'governance.voting.canVote',
                 'governance.proxy.designateProxy',
                 'governance.proxy.representPrincipal',
-                'pins.view.own',
+                'pins.view.self',
             ],
         ],
         'member.temporarybanned' => [

--- a/config/roles.php
+++ b/config/roles.php
@@ -75,6 +75,7 @@ return [
         'rfidTags.edit.all',
         'rfidTags.destroy',
         'pins.view.all',
+        'pins.view.own',
         'pins.reactivate',
         'login.shell',
         'login.spacenet',
@@ -254,6 +255,7 @@ return [
                 'governance.voting.canVote',
                 'governance.proxy.designateProxy',
                 'governance.proxy.representPrincipal',
+                'pins.view.own',
             ],
         ],
         'member.temporarybanned' => [

--- a/resources/views/card/access.blade.php
+++ b/resources/views/card/access.blade.php
@@ -12,10 +12,10 @@
     <li class="list-group-item">Roden Street Door: {{ $roden }}</li>
     @endif
     <li class="list-group-item">{{ Auth::user() == $user ? 'You have' : $user->getFirstname() . ' has' }} {{ count($user->getRfidTags()) }} RFID cards.</li>
-    @can('pins.view.all')
     @if ($user->getPin())
+    @if ($user->getPin()->getState() == \HMS\Entities\Gatekeeper\PinState::ENROLL)
     <li class="list-group-item">Pin <b>{{ $user->getPin()->getPin() }}</b> is currently set to <i>{{ $user->getPin()->getStateString() }}.</i></li>
-    @endcan
+    @endif
     @endif
   </ul>
   <div class="card-footer">

--- a/resources/views/card/access.blade.php
+++ b/resources/views/card/access.blade.php
@@ -12,7 +12,7 @@
     <li class="list-group-item">Roden Street Door: {{ $roden }}</li>
     @endif
     <li class="list-group-item">{{ Auth::user() == $user ? 'You have' : $user->getFirstname() . ' has' }} {{ count($user->getRfidTags()) }} RFID cards.</li>
-    @canany(['pins.view.all', 'pins.view.own'])
+    @canany(['pins.view.all', 'pins.view.self'])
     @if ($user->getPin())
     @if ($user->getPin()->getState() == \HMS\Entities\Gatekeeper\PinState::ENROLL || Gate::check('pins.view.all'))
     <li class="list-group-item">Pin <b>{{ $user->getPin()->getPin() }}</b> is currently set to <i>{{ $user->getPin()->getStateString() }}.</i></li>

--- a/resources/views/card/access.blade.php
+++ b/resources/views/card/access.blade.php
@@ -12,11 +12,13 @@
     <li class="list-group-item">Roden Street Door: {{ $roden }}</li>
     @endif
     <li class="list-group-item">{{ Auth::user() == $user ? 'You have' : $user->getFirstname() . ' has' }} {{ count($user->getRfidTags()) }} RFID cards.</li>
+    @canany(['pins.view.all', 'pins.view.own'])
     @if ($user->getPin())
-    @if ($user->getPin()->getState() == \HMS\Entities\Gatekeeper\PinState::ENROLL)
+    @if ($user->getPin()->getState() == \HMS\Entities\Gatekeeper\PinState::ENROLL || Gate::check('pins.view.all'))
     <li class="list-group-item">Pin <b>{{ $user->getPin()->getPin() }}</b> is currently set to <i>{{ $user->getPin()->getStateString() }}.</i></li>
     @endif
     @endif
+    @endcan
   </ul>
   <div class="card-footer">
     <a href="{{ route('users.rfid-tags', $user->getId()) }}" class="btn btn-primary mb-1">Manage RFID Cards</a>

--- a/resources/views/emails/membership/membershipComplete.blade.php
+++ b/resources/views/emails/membership/membershipComplete.blade.php
@@ -6,6 +6,8 @@
 The {{ config('branding.space_type') }} members guide can be found at {{ $membersGuideHTML }} and it is a recommended read for all members. <br>
 A PDF version is also available [here.]({{ $membersGuidePDF }})
 
+A guide to setting up your RFID door card can be found at {{ $gatekeeperSetupGuide }} - for this you will also need to know your unique, single-use PIN, {{ $membershipPIN }}.
+
 In terms of access, the street door code is **{{ $outerDoorCode }}**, and all other doors, including the doors in the stairwell and studio, are **{{ $innerDoorCode }}**. Obviously, please do not share these with non-members.
 
 Wifi access:<br>

--- a/resources/views/emails/membership/membershipComplete.blade.php
+++ b/resources/views/emails/membership/membershipComplete.blade.php
@@ -6,7 +6,7 @@
 The {{ config('branding.space_type') }} members guide can be found at {{ $membersGuideHTML }} and it is a recommended read for all members. <br>
 A PDF version is also available [here.]({{ $membersGuidePDF }})
 
-A guide to setting up your RFID door card can be found at {{ $gatekeeperSetupGuide }} - for this you will also need to know your unique, single-use PIN, {{ $membershipPIN }}.
+A guide to setting up your RFID door card can be found at {{ $gatekeeperSetupGuide }} - for this you will also need to know your unique, single-use PIN, {{ $membershipPin }}.
 
 In terms of access, the street door code is **{{ $outerDoorCode }}**, and all other doors, including the doors in the stairwell and studio, are **{{ $innerDoorCode }}**. Obviously, please do not share these with non-members.
 


### PR DESCRIPTION
As discussed with Andrew and the membership team - since we no longer ask members to come to the next open night to collect their card, we have been emailing the user with their gatekeeper pin and link to instructions on the wiki. Since this pin can only be used once, unless being reactivated, we do not see any disadvantages to these changes, and will save a great deal of admin.

The changes also allow the pin to be shown within HMS, if it's set to enrol, regardless of what groups a user is in.

Feedback appreciated, especially if we've missed something re pin activations.

cheers
Aaron

