### PR TITLE
[WIP] Account Removal

### DIFF
--- a/app/HMS/Entities/Banking/BankTransaction.php
+++ b/app/HMS/Entities/Banking/BankTransaction.php
@@ -4,8 +4,9 @@ namespace HMS\Entities\Banking;
 
 use Carbon\Carbon;
 use HMS\Entities\Snackspace\Transaction;
+use HMS\Entities\EntityObfuscatableInterface;
 
-class BankTransaction
+class BankTransaction implements EntityObfuscatableInterface
 {
     /**
      * @var int
@@ -168,6 +169,22 @@ class BankTransaction
     public function setTransaction($transaction)
     {
         $this->transaction = $transaction;
+
+        return $this;
+    }
+
+    /**
+     * Remove any personal information from the transaction.
+     * This should only happen after 7 years if the member has deleted their account.
+     */
+    public function obfuscate() {
+        $historic = Carbon::now();
+        $historic->subYears(7);
+
+        if ($this->transactionDate() < $historic) {
+            // The description may contain names etc.
+            $this->description = "obfuscated";
+        }
 
         return $this;
     }

--- a/app/HMS/Entities/EntityObfuscatableInterface.php
+++ b/app/HMS/Entities/EntityObfuscatableInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace HMS\Entities;
+
+interface EntityObfuscatableInterface
+{
+
+    /**
+     * Obfuscate an entity upon account deletion
+     * or scheduled governance cleanup.
+     */
+    public function obfuscate();
+}

--- a/app/HMS/Entities/Profile.php
+++ b/app/HMS/Entities/Profile.php
@@ -6,7 +6,7 @@ use Carbon\Carbon;
 use HMS\Governance\VotingPreference;
 use HMS\Traits\Entities\Timestampable;
 
-class Profile
+class Profile implements EntityObfuscatableInterface
 {
     use Timestampable;
 
@@ -448,6 +448,20 @@ class Profile
     public function setVotingPreferenceStatedAt(?Carbon $votingPreferenceStatedAt): self
     {
         $this->votingPreferenceStatedAt = $votingPreferenceStatedAt;
+
+        return $this;
+    }
+
+    /**
+     * Remove any personal information from the profile
+     */
+    public function obfuscate() {
+        $this->unlockText = "deleted";
+        $this->contactNumber = "deleted";
+        $this->dateOfBirth = Carbon::create(1900, 1, 1, 0, 0, 0);
+        $this->discordUsername = null;
+        $this->creditLimit = 0;
+        $this->balance = 0;
 
         return $this;
     }

--- a/app/HMS/Entities/Profile.php
+++ b/app/HMS/Entities/Profile.php
@@ -456,12 +456,10 @@ class Profile implements EntityObfuscatableInterface
      * Remove any personal information from the profile
      */
     public function obfuscate() {
-        $this->unlockText = "deleted";
-        $this->contactNumber = "deleted";
+        $this->unlockText = null;
+        $this->contactNumber = null;
         $this->dateOfBirth = Carbon::create(1900, 1, 1, 0, 0, 0);
         $this->discordUsername = null;
-        $this->creditLimit = 0;
-        $this->balance = 0;
 
         return $this;
     }

--- a/app/HMS/Entities/Snackspace/VendLog.php
+++ b/app/HMS/Entities/Snackspace/VendLog.php
@@ -4,8 +4,9 @@ namespace HMS\Entities\Snackspace;
 
 use Carbon\Carbon;
 use HMS\Entities\User;
+use HMS\Entities\EntityObfuscatableInterface;
 
-class VendLog
+class VendLog implements EntityObfuscatableInterface
 {
     /**
      * @var int
@@ -210,6 +211,23 @@ class VendLog
     public function setPosition($position)
     {
         $this->position = $position;
+
+        return $this;
+    }
+
+
+    /**
+     * Remove any personal information from the transaction.
+     * This should only happen after 7 years if the member has deleted their account.
+     */
+    public function obfuscate() {
+        $historic = Carbon::now();
+        $historic->subYears(7);
+
+        if ($this->transactionDate() < $historic) {
+            $this->rfidSerial = null;
+            $this->user = null;
+        }
 
         return $this;
     }

--- a/app/HMS/Entities/Tools/Usage.php
+++ b/app/HMS/Entities/Tools/Usage.php
@@ -4,8 +4,9 @@ namespace HMS\Entities\Tools;
 
 use Carbon\Carbon;
 use HMS\Entities\User;
+use HMS\Entities\EntityObfuscatableInterface;
 
-class Usage
+class Usage implements EntityObfuscatableInterface
 {
     /**
      * @var int
@@ -176,6 +177,15 @@ class Usage
     public function setStatus($status)
     {
         $this->status = $status;
+
+        return $this;
+    }
+
+    /**
+     * Disassociate the usage from a specific user
+     */
+    public function obfuscate() {
+        $this->user = null;
 
         return $this;
     }

--- a/app/HMS/Entities/User.php
+++ b/app/HMS/Entities/User.php
@@ -24,6 +24,7 @@ use LaravelDoctrine\ACL\Contracts\HasRoles as HasRoleContract;
 use LaravelDoctrine\ACL\Permissions\HasPermissions;
 use LaravelDoctrine\ACL\Roles\HasRoles;
 use LaravelDoctrine\ORM\Notifications\Notifiable;
+use Carbon\Carbon;
 
 class User implements
     AuthenticatableContract,
@@ -495,7 +496,7 @@ class User implements
      */
     public function obfuscate()
     {
-        $this->email = null;
+        $this->email = 'deleted-account+' . $this->username . '@deleted-accounts.local';
         return $this;
     }
 }

--- a/app/HMS/Entities/User.php
+++ b/app/HMS/Entities/User.php
@@ -497,6 +497,7 @@ class User implements
     public function obfuscate()
     {
         $this->email = 'deleted-account+' . $this->username . '@deleted-accounts.local';
+        $this->account = null;
         return $this;
     }
 }

--- a/app/HMS/Entities/User.php
+++ b/app/HMS/Entities/User.php
@@ -11,6 +11,7 @@ use HMS\Traits\Entities\DoctrineMustVerifyEmail;
 use HMS\Traits\Entities\SoftDeletable;
 use HMS\Traits\Entities\Timestampable;
 use HMS\Traits\HasApiTokens;
+use HMS\Entities\EntityObfuscatableInterface;
 use Illuminate\Auth\Passwords\CanResetPassword;
 use Illuminate\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
@@ -30,7 +31,8 @@ class User implements
     HasRoleContract,
     HasPermissionsContract,
     AuthorizableContract,
-    MustVerifyEmailContract
+    MustVerifyEmailContract,
+    EntityObfuscatableInterface
 {
     use CanResetPassword,
         Notifiable,
@@ -486,5 +488,14 @@ class User implements
                 'recipient_id' => $discordMember->user->id,
             ])
             ->id;
+    }
+
+    /**
+     * Obfuscate personal information
+     */
+    public function obfuscate()
+    {
+        $this->email = null;
+        return $this;
     }
 }

--- a/app/Http/Controllers/Auth/DeleteAccountController.php
+++ b/app/Http/Controllers/Auth/DeleteAccountController.php
@@ -56,7 +56,14 @@ class DeleteAccountController extends Controller
             return redirect()->back();
         }
 
-        //event(new AccountDeletion($user));
+        // BankTransactions will be handled by audit job. These will
+        // be obfuscated if they are older than seven years and the
+        // account has been removed. Same for VendLog.
+        // Unimportant information from Profile will be removed.
+        // Email address is removed from User.
+
+
+
 
         return redirect()->route('home');
     }

--- a/app/Http/Controllers/Auth/DeleteAccountController.php
+++ b/app/Http/Controllers/Auth/DeleteAccountController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use HMS\Auth\PasswordStore;
+use HMS\Entities\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class DeleteAccountController extends Controller
+{
+    /**
+     * @var PasswordStore
+     */
+    protected $passwordStore;
+
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct(PasswordStore $passwordStore)
+    {
+        $this->passwordStore = $passwordStore;
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function info()
+    {
+        return view('user.deleteAccount')->with('user', Auth::user());
+    }
+
+    /**
+     * Initiate the account removal process
+     *
+     * @param \Illuminate\Http\Request $request
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function delete(Request $request)
+    {
+        $user = Auth::user();
+
+        $valideCurrentPassword = Auth::guard()->validate([
+            'username' => $user->getUsername(),
+            'password' => $request->currentPassword,
+        ]);
+
+        if (! $valideCurrentPassword) {
+            flash('Your current password does not matches with the password you provided. Please try again.')->error();
+            return redirect()->back();
+        }
+
+        //event(new AccountDeletion($user));
+
+        return redirect()->route('home');
+    }
+
+    /**
+     * Set the user's password.
+     *
+     * @param \Illuminate\Contracts\Auth\CanResetPassword  $user
+     * @param string  $password
+     *
+     * @return void
+     */
+    protected function setUserPassword($user, $password)
+    {
+        $this->passwordStore->setPassword($user->getUsername(), $password);
+    }
+}

--- a/app/Http/Controllers/Auth/DeleteAccountController.php
+++ b/app/Http/Controllers/Auth/DeleteAccountController.php
@@ -106,10 +106,12 @@ class DeleteAccountController extends Controller
         $this->userRepository->save($user);
         $this->profileRepository->save($profile);
 
-//        event(new AccountDeletion($user));
+        //        event(new AccountDeletion($user));
+
+        // TODO: illuminate unique is excluding deleted items during validation
+        // but database insertion fails. i dont want usernames to be recycled anyway.
 
         return redirect()->route('home');
     }
-
 
 }

--- a/resources/views/user/deleteAccount.blade.php
+++ b/resources/views/user/deleteAccount.blade.php
@@ -1,0 +1,77 @@
+@extends('layouts.app')
+
+@section('pageTitle', 'Account Removal '.$user->getFirstname())
+
+  @section('content')
+    <div class="container">
+      <div class="row justify-content-center">
+        <div class="col-md-8">
+          <div class="card">
+            <div class="card-header">
+              <h5>Account Removal</h5>
+            </div>
+
+            <form id="delete-account-form" role="form" method="POST" action="{{ route('users.deleteAccount.deleted') }}">
+              @csrf
+              @method('PUT')
+              <div class="card-body">
+
+                <p class="card-text">
+                  As described in our privacy policy, it is possible
+                  to remove your account from the hackspace. This
+                  happens automatically after being an ex-member for
+                  six years. If you decide you want perform the
+                  account removal immediately, you need to understand
+                  the following.
+                </p>
+
+                <ul class="card-text">
+
+                  <li>
+                    If you wish to resume your membership to the
+                    hackspace, you must reattend a tour regardless of
+                    how long you were a member prior to making this
+                    account removal request.
+                  </li>
+                  <li>
+                    The hackspace will retainq your full name and
+                    address will be retained for the duration of ten
+                    years from the date of this request. This is a
+                    legal obligation of being a member of a Limited by
+                    Guarentee company.
+                  </li>
+                  <li>
+                    Information relating to your use of tools and
+                    access to the building will be annonymised
+                    immediately, but retained indefinitely.
+                  </li>
+                  <li>
+                    Payment transactions are retained for the duration
+                    of seven years, as required by HMRC for tax
+                    purposes. Transactions older than this will
+                    automatically be anonymised.
+                  </li>
+                </ul>
+
+                <p class="card-text">
+                  If you wish to remove your account, please confirm your password
+                  below.
+                </p>
+
+                <input placeholder="Current Password" class="form-control" id="currentPassword" type="password" name="currentPassword" required autofocus autocomplete="current-password">
+                @if ($errors->has('currentPassword'))
+                  <span class="help-block">
+                    <strong>{{ $errors->first('currentPassword') }}</strong>
+                  </span><br>
+                @endif
+
+              </div>
+              <div class="card-footer">
+                <button type="submit" class="btn btn-danger btn-block">Remove Account</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+  @endsection

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -77,6 +77,8 @@
   <a href="{{ route('membership.edit', Auth::user()->getId()) }}" class="btn btn-primary btn-block" >Update Details</a>
   @elseif (($user == Auth::user() && Auth::user()->can('profile.edit.self')) || ($user->getId() != Auth::user()->getId() && Auth::user()->can('profile.edit.all')))
   <a href="{{ route('users.edit', $user->getID()) }}" class="btn btn-info btn-block"><i class="fas fa-pencil" aria-hidden="true"></i> Edit</a>
+  <br />
+  <a href="{{ route('users.deleteAccount') }}" class="btn btn-danger btn-block"><i class="fas fa-trash" aria-hidden="true"></i> Remove Account</a>
   @endif
 </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -107,6 +107,10 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::get('change-password', 'Auth\ChangePasswordController@edit')->name('users.changePassword');
     Route::put('change-password', 'Auth\ChangePasswordController@update')->name('users.changePassword.update');
 
+    // User account deletion
+    Route::get('delete-account', 'Auth\DeleteAccountController@info')->name('users.deleteAccount');
+    Route::put('delete-account', 'Auth\DeleteAccountController@delete')->name('users.deleteAccount.deleted');
+
     // Meta area covers various setting for HMS
     Route::resource('metas', 'MetaController')
         ->except(['show', 'store', 'create', 'destroy']);


### PR DESCRIPTION
@dpslwk nowhere near finished yet, mostly wanting to know whether this approach is ok. basically added an interface called `EntityObfuscatableInterface` for the function `obfuscate`. Thought about traits and attribute annotations but not sure if that's a better approach.

in terms of obfuscation so far, if a user performs an account removal:
- remove all roles regardless of whether retain is set.
- clear non-required fields from `User` (we need to retain name and address for 10 years) - so just the email address at the moment, and unlink it from `Account`
- clear non-required fields from `Profile` 

for bank transactions, we need to keep those for seven years but I dont see any harm in keeping them longer. I started looking into finding historic transactions which are no longer linked to users - we can keep the amount and linked account, but just erase the description (after 7 years). probably best to have a separate job to go through this view:

```
CREATE VIEW `vw_historic_unlinked_transactions` AS
SELECT bt.* FROM bank_transactions bt
JOIN accounts a ON bt.account_id = a.id
WHERE a.id NOT IN (
   SELECT DISTINCT(user.account_id) FROM user WHERE user.account_id IS NOT NULL
)
AND bt.transaction_date < DATE_SUB(NOW(),INTERVAL 7 YEAR);
```

for snackspace transactions, I don't think we need to do anything, but we might to unlink them from a `User` after they request removal, retaining the actual transactions for statistics.

similar for door logs, unless we decide it would be best to unlink these after 3 years regardless of account deletion.


cheers
