### PR TITLE
Prevent rejected member approval until its been updated by user

### DIFF
--- a/app/Http/Controllers/MembershipController.php
+++ b/app/Http/Controllers/MembershipController.php
@@ -199,6 +199,17 @@ class MembershipController extends Controller
             return redirect()->route('home');
         }
 
+        // Check that it hasn't already been rejected by someone who got there first.
+        $rejectedLogs = $this->rejectedLogRepository->findByUser($user);
+        if (! empty($rejectedLogs)) {
+            $rejectedLog = array_pop($rejectedLogs);
+            if (! $rejectedLog->getUserUpdatedAt()) {
+                flash('This profile has already been rejected but not yet updated by the user.')->error();
+
+                return redirect()->route('membership.index');
+            }
+        }
+
         $this->validate($request, [
             'new-account' => 'required|boolean',
             'existing-account' => 'required_if:new-account,false|exists:HMS\Entities\Banking\Account,id',


### PR DESCRIPTION
sorry for the mass of PRs this weekend - this one is to avoid something which happened today where another membership team member accepted a request after i'd already rejected it. We were possibly on the same page already.