### PR TITLE
Daily Discord Audit Job

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -3,8 +3,8 @@
 namespace App\Console;
 
 use App\Jobs\Banking\MembershipAuditJob;
-use App\Jobs\EmailTeamReminderJob;
 use App\Jobs\DiscordAuditJob;
+use App\Jobs\EmailTeamReminderJob;
 use App\Jobs\Gatekeeper\TemporaryAcccessCheckZoneOccupancyJob;
 use App\Jobs\Gatekeeper\UpdateTemporaryAccessRoleJob;
 use App\Jobs\Gatekeeper\ZoneOccupantResetJob;

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -4,6 +4,7 @@ namespace App\Console;
 
 use App\Jobs\Banking\MembershipAuditJob;
 use App\Jobs\EmailTeamReminderJob;
+use App\Jobs\DiscordAuditJob;
 use App\Jobs\Gatekeeper\TemporaryAcccessCheckZoneOccupancyJob;
 use App\Jobs\Gatekeeper\UpdateTemporaryAccessRoleJob;
 use App\Jobs\Gatekeeper\ZoneOccupantResetJob;
@@ -67,6 +68,11 @@ class Kernel extends ConsoleKernel
                 );
             })
             ->everyFiveMinutes();
+        }
+
+        if (config('services.discord.token')) {
+            $schedule->job(new DiscordAuditJob)
+                     ->dailyAt('12:15');
         }
     }
 

--- a/app/HMS/Helpers/Discord.php
+++ b/app/HMS/Helpers/Discord.php
@@ -90,15 +90,7 @@ class Discord
      */
     public function findMemberByUsername(string $username)
     {
-        if (! $this->members) {
-            // This supports pagination in chunks of 1000 by setting the
-            // 'after' parameter to the last member user id. I don't think
-            // we need to worry about this yet.
-            $this->members = $this->client->guild->listGuildMembers([
-                'guild.id' => $this->guildId,
-                'limit' => 1000,
-            ]);
-        }
+        $this->listGuildMembers(); // populate cache
 
         // Evolving Usernames on Discord
         // https://discord.com/blog/usernames
@@ -131,6 +123,25 @@ class Discord
         }
 
         return null;
+    }
+
+    /**
+     * Return a list of all guild members
+     *
+     * @return array
+     */
+    public function listGuildMembers() {
+        if (! $this->members) {
+            // This supports pagination in chunks of 1000 by setting the
+            // 'after' parameter to the last member user id. I don't think
+            // we need to worry about this yet.
+            $this->members = $this->client->guild->listGuildMembers([
+                'guild.id' => $this->guildId,
+                'limit' => 1000,
+            ]);
+        }
+
+        return $this->members;
     }
 
     /**

--- a/app/HMS/Helpers/Discord.php
+++ b/app/HMS/Helpers/Discord.php
@@ -126,11 +126,12 @@ class Discord
     }
 
     /**
-     * Return a list of all guild members
+     * Return a list of all guild members.
      *
      * @return array
      */
-    public function listGuildMembers() {
+    public function listGuildMembers()
+    {
         if (! $this->members) {
             // This supports pagination in chunks of 1000 by setting the
             // 'after' parameter to the last member user id. I don't think

--- a/app/HMS/Repositories/Doctrine/DoctrineProfileRepository.php
+++ b/app/HMS/Repositories/Doctrine/DoctrineProfileRepository.php
@@ -119,7 +119,6 @@ class DoctrineProfileRepository extends EntityRepository implements ProfileRepos
         return (int) $q->getQuery()->getSingleScalarResult() ?? 0;
     }
 
-
     /**
      * @param string $discordUsername
      *

--- a/app/HMS/Repositories/Doctrine/DoctrineProfileRepository.php
+++ b/app/HMS/Repositories/Doctrine/DoctrineProfileRepository.php
@@ -119,6 +119,17 @@ class DoctrineProfileRepository extends EntityRepository implements ProfileRepos
         return (int) $q->getQuery()->getSingleScalarResult() ?? 0;
     }
 
+
+    /**
+     * @param string $discordUsername
+     *
+     * @return Profile|null
+     */
+    public function findOneByDiscordUsername(string $discordUsername)
+    {
+        return parent::findOneByDiscordUsername($discordUsername);
+    }
+
     /**
      * Save Profile to the DB.
      *

--- a/app/HMS/Repositories/ProfileRepository.php
+++ b/app/HMS/Repositories/ProfileRepository.php
@@ -49,6 +49,13 @@ interface ProfileRepository
     public function totalCreditForExMembers();
 
     /**
+     * @param string $discordUsername
+     *
+     * @return Profile|null
+     */
+    public function findOneByDiscordUsername(string $discordUsername);
+
+    /**
      * Save Profile to the DB.
      *
      * @param Profile $profile

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -81,6 +81,20 @@ class UserController extends Controller
     }
 
     /**
+     * Redirects to edit($user) based on logged in user.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function editRedirect()
+    {
+        if (Auth::user()) {
+            return redirect()->route('users.edit', (Auth::user())->getId());
+        }
+
+        return redirect()->route('login');
+    }
+
+    /**
      * Show the form for editing the specified user.
      *
      * @param User $user

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -88,7 +88,7 @@ class UserController extends Controller
     public function editRedirect()
     {
         if (Auth::user()) {
-            return redirect()->route('users.edit', (Auth::user())->getId());
+            return redirect()->route('users.edit', Auth::user()->getId());
         }
 
         return redirect()->route('login');

--- a/app/Jobs/DiscordAuditJob.php
+++ b/app/Jobs/DiscordAuditJob.php
@@ -34,7 +34,7 @@ class DiscordAuditJob implements ShouldQueue
      * @return void
     private function notifyDiscordUser(Discord $discord, $discordMember)
     {
-        $link = route('home');
+        $link = route('redirector.user.edit');
         $message = <<<EOF
         __**Discord username not found in HMS**__
 

--- a/app/Jobs/DiscordAuditJob.php
+++ b/app/Jobs/DiscordAuditJob.php
@@ -40,8 +40,8 @@ class DiscordAuditJob implements ShouldQueue
         __**Discord username not found in HMS**__
 
         Unfortunately we were not able to locate your Discord username in HMS.
-        Have you recently changed your Discord username? Please ensure you update
-        this on your HMS profile.
+
+        Have you recently changed your Discord username? Please ensure you update this on your HMS profile.
 
         $link
         EOF;

--- a/app/Jobs/DiscordAuditJob.php
+++ b/app/Jobs/DiscordAuditJob.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace App\Jobs;
+
+use HMS\Entities\Role;
+use HMS\Entities\Profile;
+use HMS\Repositories\ProfileRepository;
+use HMS\Helpers\Discord;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class DiscordAuditJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     */
+    public function __construct() {
+        // Nothing to do here...
+    }
+
+    /**
+     * Sends a DM to the Discord user letting them know roles have been removed.
+     *
+     * @param Discord $discord
+     * @param DiscordUser $discordMember
+     *
+     * @return void
+    private function notifyDiscordUser(Discord $discord, $discordMember)
+    {
+        $link = route('home');
+        $message = <<<EOF
+        __**Discord username not found in HMS**__
+
+        Unfortunately we were not able to locate your Discord username in HMS.
+        Have you recently changed your Discord username? Please ensure you update
+        this on your HMS profile.
+
+        $link
+        EOF;
+
+        $channel = $discord->getDiscordClient()->user->createDm([
+                     'recipient_id' => (int) $discordMember['user']['id'],
+                 ]);
+
+        $discord->getDiscordClient()->channel->createMessage([
+            'channel.id' => (int)$channel['id'],
+            'content' => $message
+        ]);
+    }
+
+    /**
+     * Removes all roles from the discord user.
+     *
+     * @param Discord $discord
+     * @param DiscordUser $discordMember
+     *
+     * @return void
+     */
+    private function stripRoles(Discord $discord, $discordMember)
+    {
+        foreach ($discordMember['roles'] as $discordRoleId) {
+            $discord->getDiscordClient()->guild->removeGuildMemberRole([
+                'guild.id' => config('services.discord.guild_id'),
+                'user.id' => (int) $discordMember['user']['id'],
+                'role.id' => (int) $discordRoleId,
+            ]);
+        }
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @param ProfileRepository $profileRepository
+     *
+     * @return void
+     */
+    public function handle(
+        ProfileRepository $profileRepository
+    ) {
+        $discord = new Discord(
+            config('services.discord.token'),
+            config('services.discord.guild_id')
+        );
+
+        $currentMember = $discord->findRoleByName('Current Member')['id'];
+        $members = $discord->listGuildMembers();
+
+        foreach($members as $member) {
+            // If the Discord user doesn't have the "Current Member" role, we can skip past them.
+            if(! in_array($currentMember, $member['roles'])) {
+                continue;
+            }
+
+            // Attempt to find the user using just their Discord
+            // username, we need to try again with the discriminator
+            // included.
+            $profile = $profileRepository->findOneByDiscordUsername($member['user']['username']);
+            if (! $profile) {
+                if ((int)$member['user']['discriminator'] > 0) {
+                    $discordUsername = $member['user']['username'] . '#' . $member['user']['discriminator'];
+                    $profile = $profileRepository->findOneByDiscordUsername($discordUsername);
+                }
+            };
+
+            // Assuming we found a profile, make sure they are
+            // actually a current member, otherwise strip off any Discord
+            // roles.
+            $found = false;
+            if ($profile) {
+                $roles = $profile->getUser()->getRoles();
+
+                foreach ($roles as $role) {
+                    if ($role->getName() == "member.current") {
+                        $found = true;
+                        break;
+                    }
+                }
+            }
+
+            // If they're not found, send them a message to notify
+            // them, and then strip the roles.
+            if (! $found) {
+                Log::info('DiscordAuditJob@handle: Removing roles from unknown Discord user ' .
+                          $member['user']['username'] . '#' . $member['user']['discriminator']);
+                $this->notifyDiscordUser($discord, $member);
+                $this->stripRoles($discord, $member);
+            }
+        };
+    }
+}

--- a/app/Jobs/DiscordAuditJob.php
+++ b/app/Jobs/DiscordAuditJob.php
@@ -2,10 +2,10 @@
 
 namespace App\Jobs;
 
-use HMS\Entities\Role;
 use HMS\Entities\Profile;
-use HMS\Repositories\ProfileRepository;
+use HMS\Entities\Role;
 use HMS\Helpers\Discord;
+use HMS\Repositories\ProfileRepository;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -19,9 +19,9 @@ class DiscordAuditJob implements ShouldQueue
 
     /**
      * Create a new job instance.
-     *
      */
-    public function __construct() {
+    public function __construct()
+    {
         // Nothing to do here...
     }
 
@@ -47,12 +47,12 @@ class DiscordAuditJob implements ShouldQueue
         EOF;
 
         $channel = $discord->getDiscordClient()->user->createDm([
-                     'recipient_id' => (int) $discordMember['user']['id'],
-                 ]);
+            'recipient_id' => (int) $discordMember['user']['id'],
+        ]);
 
         $discord->getDiscordClient()->channel->createMessage([
-            'channel.id' => (int)$channel['id'],
-            'content' => $message
+            'channel.id' => (int) $channel['id'],
+            'content' => $message,
         ]);
     }
 
@@ -93,9 +93,9 @@ class DiscordAuditJob implements ShouldQueue
         $currentMember = $discord->findRoleByName('Current Member')['id'];
         $members = $discord->listGuildMembers();
 
-        foreach($members as $member) {
+        foreach ($members as $member) {
             // If the Discord user doesn't have the "Current Member" role, we can skip past them.
-            if(! in_array($currentMember, $member['roles'])) {
+            if (! in_array($currentMember, $member['roles'])) {
                 continue;
             }
 
@@ -104,11 +104,11 @@ class DiscordAuditJob implements ShouldQueue
             // included.
             $profile = $profileRepository->findOneByDiscordUsername($member['user']['username']);
             if (! $profile) {
-                if ((int)$member['user']['discriminator'] > 0) {
+                if ((int) $member['user']['discriminator'] > 0) {
                     $discordUsername = $member['user']['username'] . '#' . $member['user']['discriminator'];
                     $profile = $profileRepository->findOneByDiscordUsername($discordUsername);
                 }
-            };
+            }
 
             // Assuming we found a profile, make sure they are
             // actually a current member, otherwise strip off any Discord
@@ -118,7 +118,7 @@ class DiscordAuditJob implements ShouldQueue
                 $roles = $profile->getUser()->getRoles();
 
                 foreach ($roles as $role) {
-                    if ($role->getName() == "member.current") {
+                    if ($role->getName() == 'member.current') {
                         $found = true;
                         break;
                     }
@@ -133,6 +133,6 @@ class DiscordAuditJob implements ShouldQueue
                 $this->notifyDiscordUser($discord, $member);
                 $this->stripRoles($discord, $member);
             }
-        };
+        }
     }
 }

--- a/app/Jobs/DiscordAuditJob.php
+++ b/app/Jobs/DiscordAuditJob.php
@@ -32,6 +32,7 @@ class DiscordAuditJob implements ShouldQueue
      * @param DiscordUser $discordMember
      *
      * @return void
+     */
     private function notifyDiscordUser(Discord $discord, $discordMember)
     {
         $link = route('redirector.user.edit');

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,9 +1,9 @@
 <?php
 
 use App\Jobs\Banking\MembershipAuditJob;
+use App\Jobs\DiscordAuditJob;
 use App\Jobs\Gatekeeper\ZoneOccupantResetJob;
 use App\Jobs\Membership\AuditYoungHackersJob;
-use App\Jobs\DiscordAuditJob;
 use App\Jobs\PostGitDeployedJob;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;

--- a/routes/console.php
+++ b/routes/console.php
@@ -3,6 +3,7 @@
 use App\Jobs\Banking\MembershipAuditJob;
 use App\Jobs\Gatekeeper\ZoneOccupantResetJob;
 use App\Jobs\Membership\AuditYoungHackersJob;
+use App\Jobs\DiscordAuditJob;
 use App\Jobs\PostGitDeployedJob;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
@@ -37,3 +38,7 @@ Artisan::command('hms:members:audit', function () {
 Artisan::command('hms:members:youngHackerAudit', function () {
     AuditYoungHackersJob::dispatchSync();
 })->describe('Audit young hackers for any that have turned 18');
+
+Artisan::command('hms:discord:audit', function () {
+    DiscordAuditJob::dispatchSync();
+})->describe('Audit Discord member roles');

--- a/routes/web.php
+++ b/routes/web.php
@@ -78,7 +78,6 @@ Route::middleware(['auth'])->group(function () {
     // Users (show, edit, update) to allow users to update there email if they can't verify it
     Route::resource('users', 'UserController')
         ->except(['index', 'store', 'create', 'destroy']);
-
 });
 
 // Routes in the following group can only be access once logged-in and have verified your email address

--- a/routes/web.php
+++ b/routes/web.php
@@ -72,9 +72,13 @@ Route::middleware(['auth'])->group(function () {
     Route::get('membership/update-details/{user}', 'MembershipController@editDetails')->name('membership.edit');
     Route::put('membership/update-details/{user}', 'MembershipController@updateDetails')->name('membership.update');
 
+    // A redirector to go to the currently logged in users edit user page.
+    Route::get('profile', 'UserController@editRedirect')->name('redirector.user.edit');
+
     // Users (show, edit, update) to allow users to update there email if they can't verify it
     Route::resource('users', 'UserController')
         ->except(['index', 'store', 'create', 'destroy']);
+
 });
 
 // Routes in the following group can only be access once logged-in and have verified your email address


### PR DESCRIPTION
This adds a daily job which runs at 12:15 each day. It goes through each user on Discord with the "Current Member" role and makes sure they are actually a current member. This is needed to ensure HMS team roles are kept in sync with Discord, which can't happen if someone changes their Discord username (either forced, due to legacy discriminator, or preference).

The user will receive a DM when this happens with an explanation and link to update their details.

To make it as easy as possible for a user to update their Discord username, a new web route has been added `/profile` which redirects to `/users/{current user}/edit`.