### PR TITLE
Use Discord User Snowflake for Role management and Notifications

### DIFF
--- a/app/HMS/Entities/Profile.php
+++ b/app/HMS/Entities/Profile.php
@@ -76,6 +76,11 @@ class Profile
     protected $discordUsername;
 
     /**
+     * @var null|string
+     */
+    protected $discordUserSnowflake;
+
+    /**
      * @var int
      */
     protected $balance;
@@ -365,6 +370,26 @@ class Profile
     public function setDiscordUsername(?string $discordUsername): self
     {
         $this->discordUsername = $discordUsername;
+
+        return $this;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getDiscordUserSnowflake(): ?string
+    {
+        return $this->discordUserSnowflake;
+    }
+
+    /**
+     * @param null|string
+     *
+     * @return self
+     */
+    public function setDiscordUserSnowflake(?string $discordUserSnowflake): self
+    {
+        $this->discordUserSnowflake = $discordUserSnowflake;
 
         return $this;
     }

--- a/app/HMS/Entities/User.php
+++ b/app/HMS/Entities/User.php
@@ -473,8 +473,7 @@ class User implements
             config('services.discord.guild_id')
         );
 
-        $discordUsername = $this->getProfile()->getDiscordUsername();
-        $discordMember = $discord->findMemberByUsername($discordUsername);
+        $discordMember = $discord->findMemberByProfile($this->getProfile());
 
         if (! $discordMember) {
             return null;

--- a/app/HMS/Helpers/Discord.php
+++ b/app/HMS/Helpers/Discord.php
@@ -126,7 +126,7 @@ class Discord
     }
 
     /**
-     * Get a member by their snowflake
+     * Get a member by their snowflake.
      *
      * @param string  Discord user snowflake
      *
@@ -146,13 +146,14 @@ class Discord
     }
 
     /**
-     * Find a Discord member from a HMS Profile
+     * Find a Discord member from a HMS Profile.
      *
      * @param Profile A HMS User Profile object
      *
      * @return null|DiscordMember
      */
-    public function findMemberByProfile($profile) {
+    public function findMemberByProfile($profile)
+    {
         if ($profile->getDiscordUserSnowflake()) {
             return $this->findMemberBySnowflake($profile->getDiscordUserSnowflake());
         }

--- a/app/HMS/Helpers/Discord.php
+++ b/app/HMS/Helpers/Discord.php
@@ -126,6 +126,41 @@ class Discord
     }
 
     /**
+     * Get a member by their snowflake
+     *
+     * @param string  Discord user snowflake
+     *
+     * @return null|DiscordMember
+     */
+    public function findMemberBySnowflake(string $snowflake)
+    {
+        $this->listGuildMembers(); // populate cache
+
+        foreach ($this->members as $member) {
+            if ($member['user']['id'] == $snowflake) {
+                return $member;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find a Discord member from a HMS Profile
+     *
+     * @param Profile A HMS User Profile object
+     *
+     * @return null|DiscordMember
+     */
+    public function findMemberByProfile($profile) {
+        if ($profile->getDiscordUserSnowflake()) {
+            return $this->findMemberBySnowflake($profile->getDiscordUserSnowflake());
+        }
+
+        return $this->findMemberByUsername($profile->getDiscordUsername());
+    }
+
+    /**
      * Return a list of all guild members.
      *
      * @return array

--- a/app/HMS/Mappings/HMS.Entities.Profile.dcm.yml
+++ b/app/HMS/Mappings/HMS.Entities.Profile.dcm.yml
@@ -67,6 +67,11 @@ HMS\Entities\Profile:
       column: discord_username
       length: 32
       nullable: true
+    discordUserSnowflake:
+      type: string
+      column: discord_user_snowflake
+      length: 32
+      nullable: true
     balance:
       type: integer
       options:

--- a/app/HMS/Repositories/Doctrine/DoctrineProfileRepository.php
+++ b/app/HMS/Repositories/Doctrine/DoctrineProfileRepository.php
@@ -130,6 +130,16 @@ class DoctrineProfileRepository extends EntityRepository implements ProfileRepos
     }
 
     /**
+     * @param string $discordUserSnowflake
+     *
+     * @return Profile|null
+     */
+    public function findOneByDiscordUserSnowflake(string $discordUserSnowflake)
+    {
+        return parent::findOneByDiscordUserSnowflake($discordUserSnowflake);
+    }
+
+    /**
      * Save Profile to the DB.
      *
      * @param Profile $profile

--- a/app/HMS/Repositories/ProfileRepository.php
+++ b/app/HMS/Repositories/ProfileRepository.php
@@ -56,6 +56,13 @@ interface ProfileRepository
     public function findOneByDiscordUsername(string $discordUsername);
 
     /**
+     * @param string $discordUserSnowflake
+     *
+     * @return Profile|null
+     */
+    public function findOneByDiscordUserSnowflake(string $discordUserSnowflake);
+
+    /**
      * Save Profile to the DB.
      *
      * @param Profile $profile

--- a/app/HMS/User/ProfileManager.php
+++ b/app/HMS/User/ProfileManager.php
@@ -177,8 +177,14 @@ class ProfileManager
             if ($oldDiscordUsername != $profile->getDiscordUsername()) {
                 event(new DiscordUsernameUpdated($user, $profile, $oldDiscordUsername));
 
-                if ($profile->getDiscordUsername()) {
-                    $user->notify(new DiscordRegistered());
+                if ($profile->getDiscordUserSnowflake()) {
+                    try {
+                        $user->notify(new DiscordRegistered());
+                    } catch (ErrorException $ex) {
+                        Log::info('ProfileManager@updateUserProfileFromRequest: Failed to notify user via Discord');
+                    }
+                } else {
+                    $profile->setDiscordUsername(null);
                 }
             }
         }

--- a/app/HMS/User/ProfileManager.php
+++ b/app/HMS/User/ProfileManager.php
@@ -10,6 +10,7 @@ use HMS\Entities\User;
 use HMS\Repositories\MetaRepository;
 use HMS\Repositories\ProfileRepository;
 use HMS\Repositories\UserRepository;
+use Illuminate\Support\Facades\Log;
 
 class ProfileManager
 {

--- a/app/Jobs/DiscordAuditJob.php
+++ b/app/Jobs/DiscordAuditJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use Exception;
 use HMS\Entities\Profile;
 use HMS\Entities\Role;
 use HMS\Helpers\Discord;

--- a/app/Jobs/DiscordAuditJob.php
+++ b/app/Jobs/DiscordAuditJob.php
@@ -99,10 +99,15 @@ class DiscordAuditJob implements ShouldQueue
                 continue;
             }
 
-            // Attempt to find the user using just their Discord
-            // username, we need to try again with the discriminator
-            // included.
-            $profile = $profileRepository->findOneByDiscordUsername($member['user']['username']);
+            // Attempt to find the user by their snowflake.
+            $profile = $profileRepository->findOneByDiscordUserSnowflake($member['user']['id']);
+
+            // Attempt to find the user using just their Discord username
+            if (! $profile) {
+                $profile = $profileRepository->findOneByDiscordUsername($member['user']['username']);
+            }
+
+            // Still stuck, try with discriminator
             if (! $profile) {
                 if ((int) $member['user']['discriminator'] > 0) {
                     $discordUsername = $member['user']['username'] . '#' . $member['user']['discriminator'];
@@ -115,6 +120,23 @@ class DiscordAuditJob implements ShouldQueue
             // roles.
             $found = false;
             if ($profile) {
+                // If we got a profile but their snowflake is empty, populate it.
+                if ($profile->getDiscordUserSnowflake() != $member['user']['id']) {
+                    $profile->setDiscordUserSnowflake($member['user']['id']);
+                    $profileRepository->save($profile);
+                }
+
+                // We can also check the username in case it changed, but they have a snowflake set.
+                if ($profile->getDiscordUsername() != $member['user']['username']) {
+                    // Just in case, I think discriminators for users are gone though.
+                    if ($member['user']['discriminator']) {
+                        $profile->setDiscordUsername($member['user']['username'] . '#' . $member['user']['discriminator']);
+                    } else {
+                        $profile->setDiscordUsername($member['user']['username']);
+                    }
+                    $profileRepository->save($profile);
+                }
+
                 $roles = $profile->getUser()->getRoles();
 
                 foreach ($roles as $role) {
@@ -130,8 +152,14 @@ class DiscordAuditJob implements ShouldQueue
             if (! $found) {
                 Log::info('DiscordAuditJob@handle: Removing roles from unknown Discord user ' .
                           $member['user']['username'] . '#' . $member['user']['discriminator']);
-                $this->notifyDiscordUser($discord, $member);
-                $this->stripRoles($discord, $member);
+
+                try {
+                    $this->stripRoles($discord, $member); // Remove roles first (more likely to succeed than messaging)
+                    $this->notifyDiscordUser($discord, $member);
+                } catch (Exception $exception) {
+                    Log::info('DiscordAuditJob@handle: Failed to remove roles or message user. ' .
+                              $exception->getMessage());
+                }
             }
         }
     }

--- a/app/Listeners/RoleUpdateDiscordUpdater.php
+++ b/app/Listeners/RoleUpdateDiscordUpdater.php
@@ -143,7 +143,7 @@ class RoleUpdateDiscordUpdater implements ShouldQueue
             return;
         }
 
-        $discordMember = $this->discord->findMemberByUsername($profile->getDiscordUsername());
+        $discordMember = $this->discord->findMemberByProfile($profile);
         $discordRole = $this->discord->findRoleByName($role->getDisplayName());
 
         if (! $discordMember || ! $discordRole) {
@@ -160,9 +160,16 @@ class RoleUpdateDiscordUpdater implements ShouldQueue
                   $user->getUsername() . ' removed from discord role ' . $role->getDisplayName());
     }
 
-    private function cleanupOldDiscordUserRoles($oldDiscordUsername)
+    /**
+     * Removes roles from a Discord member, trying their snowflake first, then username.
+     *
+     * @param Profile the HMS profile
+     */
+    private function cleanupOldDiscordUserRoles($profile)
     {
-        $discordMember = $this->discord->findMemberByUsername($oldDiscordUsername);
+        $discordMember = $this->discord->findMemberByProfile($profile);
+
+        // Give up
         if (! $discordMember) {
             return;
         }
@@ -192,21 +199,23 @@ class RoleUpdateDiscordUpdater implements ShouldQueue
         $memberTeams = $this->roleRepository->findTeamsForUser($user);
 
         if ($oldDiscordUsername) {
-            $this->cleanupOldDiscordUserRoles($oldDiscordUsername);
+            $this->cleanupOldDiscordUserRoles($profile);
+            $profile->setDiscordUserSnowflake(null);
         }
 
         if (! $profile->getDiscordUsername()) {
             return;
         }
 
-        $discordUsername = $profile->getDiscordUsername();
         $hmsUsername = $user->getUsername();
 
-        $discordMember = $this->discord->findMemberByUsername($discordUsername);
+        $discordMember = $this->discord->findMemberByProfile($profile);
 
         if (! $discordMember) {
             return;
         }
+
+        $profile->setDiscordUserSnowflake($discordMember['user']['id']);
 
         $discordMemberRole = $this->discord->findRoleByName($memberRole->getDisplayName());
         if ($discordMemberRole) {

--- a/app/Listeners/RoleUpdateDiscordUpdater.php
+++ b/app/Listeners/RoleUpdateDiscordUpdater.php
@@ -107,7 +107,7 @@ class RoleUpdateDiscordUpdater implements ShouldQueue
             return;
         }
 
-        $discordMember = $this->discord->findMemberByUsername($profile->getDiscordUsername());
+        $discordMember = $this->discord->findMemberByProfile($profile);
         $discordRole = $this->discord->findRoleByName($role->getDisplayName());
 
         if (! $discordMember || ! $discordRole) {

--- a/app/Notifications/Users/DiscordRegistered.php
+++ b/app/Notifications/Users/DiscordRegistered.php
@@ -49,7 +49,7 @@ class DiscordRegistered extends Notification implements ShouldQueue
      */
     public function toMail($notifiable)
     {
-        if (! $notifiable->getProfile()->getDiscordUsername()) {
+        if (! $notifiable->getProfile()->getDiscordUserSnowflake()) {
             return;
         }
 

--- a/database/migrations_doctrine/Version20240622102424_add_discord_user_snowflake.php
+++ b/database/migrations_doctrine/Version20240622102424_add_discord_user_snowflake.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240622102424_add_discord_user_snowflake extends AbstractMigration
+{
+    /**
+     * @param Schema $schema
+     */
+    public function up(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE profile ADD discord_user_snowflake VARCHAR(32) DEFAULT NULL');
+    }
+
+    /**
+     * @param Schema $schema
+     */
+    public function down(Schema $schema): void
+    {
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() != 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE profile DROP discord_user_snowflake');
+    }
+}

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -68,7 +68,7 @@
             <td>
               {{ $user->getProfile()->getDiscordUsername() }}
               @if ($user->getProfile()->getDiscordUserSnowflake())
-                <i>({{ $user->getProfile()->getDiscordUserSnowflake() }})</i>
+              <i>({{ $user->getProfile()->getDiscordUserSnowflake() }})</i>
               @endif
             </td>
           </tr>

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -65,13 +65,13 @@
         @feature('discord')
         <tr>
           <th>Discord Username:</th>
-            <td>
-              {{ $user->getProfile()->getDiscordUsername() }}
-              @if ($user->getProfile()->getDiscordUserSnowflake())
-              <i>({{ $user->getProfile()->getDiscordUserSnowflake() }})</i>
-              @endif
-            </td>
-          </tr>
+          <td>
+            {{ $user->getProfile()->getDiscordUsername() }}
+            @if ($user->getProfile()->getDiscordUserSnowflake())
+            <i>({{ $user->getProfile()->getDiscordUserSnowflake() }})</i>
+            @endif
+          </td>
+        </tr>
         @endfeature
         @endif
       </tbody>

--- a/resources/views/user/show.blade.php
+++ b/resources/views/user/show.blade.php
@@ -65,8 +65,13 @@
         @feature('discord')
         <tr>
           <th>Discord Username:</th>
-          <td>{{ $user->getProfile()->getDiscordUsername() }}</td>
-        </tr>
+            <td>
+              {{ $user->getProfile()->getDiscordUsername() }}
+              @if ($user->getProfile()->getDiscordUserSnowflake())
+                <i>({{ $user->getProfile()->getDiscordUserSnowflake() }})</i>
+              @endif
+            </td>
+          </tr>
         @endfeature
         @endif
       </tbody>


### PR DESCRIPTION
The audit job should take care of populating missing snowflakes.

I think all instances of `findMemberByUsername` have been replaced with a `findMemberByProfile` which will attempt to find the username by their snowflake first. Eventually I might strip out the `findMemberByUsername` stuff.

The audit job will update the `discordUsername` field if it appears to have changed. Keeping the username is useful for showing it in profile and also for the search.

Still tempted to add a separate page for linking Discord at some point, maybe with a card on the home view, but this should hopefully fix any issues for now.