### PR TITLE
Pass the 'hidden' param for Tools created with ToolFactory

### DIFF
--- a/app/HMS/Factories/Tools/ToolFactory.php
+++ b/app/HMS/Factories/Tools/ToolFactory.php
@@ -27,7 +27,8 @@ class ToolFactory
         int $pph,
         int $bookingLength,
         int $lengthMax,
-        int $bookingsMax = 1
+        int $bookingsMax = 1,
+        bool $hidden = false
     ) {
         $_tool = new Tool();
         $_tool->setName($name);
@@ -47,6 +48,7 @@ class ToolFactory
         $_tool->setBookingLength($bookingLength);
         $_tool->setLengthMax($lengthMax);
         $_tool->setBookingsMax($bookingsMax);
+        $_tool->setHidden($hidden);
 
         return $_tool;
     }

--- a/tests/Unit/HMS/Factories/Tools/ToolFactoryTest.php
+++ b/tests/Unit/HMS/Factories/Tools/ToolFactoryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit\HMS\Factories\Tools;
+
+use Tests\TestCase;
+use HMS\Factories\Tools\ToolFactory;
+
+class ToolFactoryTest extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function test_create_assigns_the_tool_name()
+    {
+        $tool = $this->factoryCreate();
+
+        $this->assertEquals('Tool Name', $tool->getName());
+    }
+
+    /**
+     * @return void
+     */
+    public function test_create_sets_the_hidden_property()
+    {
+        $tool = $this->factoryCreate();
+
+        $this->assertEquals(false, $tool->isHidden());
+    }
+
+    /**
+     * @return void
+     */
+    public function test_create_sets_the_hidden_property_when_hidden()
+    {
+        $tool = $this->factoryCreate(hidden: true);
+
+        $this->assertEquals(true, $tool->isHidden());
+    }
+
+    /**
+     * @return HMS\Entities\Tools\Tool
+     */
+    private function factoryCreate($hidden = false) {
+        $factory = new ToolFactory();
+
+        return $factory->create('Tool Name', 'Tool Description', true, 300, 30, 120, 1, $hidden);
+    }
+}
+


### PR DESCRIPTION
I spotted that the tool import for a fresh import of the database wasn't working. This is why.

The 'hidden' flag is a newly added attribute on Tools, and this was missed whilst implementing it.