### PR TITLE
Add field to 'agree to rules'

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -88,6 +88,7 @@ class RegisterController extends Controller
             'addressPostcode' => 'required|max:10',
             'contactNumber' => 'required|max:50',
             'dateOfBirth' => 'nullable|date_format:Y-m-d',
+            'agreeToRules' => 'required|boolean',
         ]);
     }
 

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -148,6 +148,16 @@
           @endif
         </div>
 
+        <div class="form-check">
+          <input id="agreeToRules" class="form-check-input{{  $errors->has('agreeToRules') ? ' is-invalid' : '' }}" type="checkbox" name="agreeToRules" value="1" required>
+          <label for="agreeToRules" class="form-check-label">I have read and agree to the <a href="{{ Meta::get('rules_html') }}">{{ config('branding.space_name') }} rules</a>.</label>
+          @if ($errors->has('agreeToRules'))
+          <span class="invalid-feedback">
+            <strong>{{ $errors->first('agreeToRules') }}</strong>
+          </span>
+          @endif
+        </div>
+
       </div>
       <div class="card-footer">
         <button type="submit" class="btn btn-success btn-block">Register</button>


### PR DESCRIPTION
This adds a checkbox to say the future-member has read and agreed to the nottinghack rules
![image](https://github.com/user-attachments/assets/07cdff23-638d-4242-bf55-8897b8c29c84)

client side validation also prevents the form from being submitted, but in the worst case:
![image](https://github.com/user-attachments/assets/27100e3f-b1f6-4702-bc88-f8f7d1339017)
