### PR TITLE
Add prometheus collector for meetings

### DIFF
--- a/app/HMS/Prometheus/Collectors/Governance/MeetingCollector.php
+++ b/app/HMS/Prometheus/Collectors/Governance/MeetingCollector.php
@@ -25,25 +25,25 @@ class MeetingCollector implements Collector
         $meetings = $meetingRepository->paginateAll();
         $meetingCounts = [];
 
-        foreach($meetings as $meeting) {
+        foreach ($meetings as $meeting) {
             $meetingCounts[] = [
                 $meeting->getProxies()->count(),
-                [$meeting->getTitle(), "attendees"]
+                [$meeting->getTitle(), 'attendees'],
             ];
 
             $meetingCounts[] = [
                 $meeting->getProxies()->count(),
-                [$meeting->getTitle(), "proxies"]
+                [$meeting->getTitle(), 'proxies'],
             ];
 
             $meetingCounts[] = [
                 $meeting->getAbsentees()->count(),
-                [$meeting->getTitle(), "absentees"]
+                [$meeting->getTitle(), 'absentees'],
             ];
 
             $meetingCounts[] = [
                 $meeting->getQuorum(),
-                [$meeting->getTitle(), "quorum"]
+                [$meeting->getTitle(), 'quorum'],
             ];
         }
 

--- a/app/HMS/Prometheus/Collectors/Governance/MeetingCollector.php
+++ b/app/HMS/Prometheus/Collectors/Governance/MeetingCollector.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace HMS\Prometheus\Collectors\Governance;
+
+use HMS\Repositories\Governance\MeetingRepository;
+use HMS\Repositories\Governance\ProxyRepository;
+use Spatie\Prometheus\Collectors\Collector;
+use Spatie\Prometheus\Facades\Prometheus;
+
+class MeetingCollector implements Collector
+{
+    public function register(): void
+    {
+        Prometheus::addGauge('Meeting Counts')
+            ->name('statistics_meeting_counts')
+            ->labels(['meeting', 'type'])
+            ->helpText('Meeting stats: quorum, attendees, proxies and absentees')
+            ->value(fn () => app()->call([$this, 'getValueAttendeeCount']));
+    }
+
+    public function getValueAttendeeCount(
+        MeetingRepository $meetingRepository,
+        ProxyRepository $proxyRepository
+    ) {
+        $meetings = $meetingRepository->paginateAll();
+        $meetingCounts = [];
+
+        foreach($meetings as $meeting) {
+            $meetingCounts[] = [
+                $meeting->getProxies()->count(),
+                [$meeting->getTitle(), "attendees"]
+            ];
+
+            $meetingCounts[] = [
+                $meeting->getProxies()->count(),
+                [$meeting->getTitle(), "proxies"]
+            ];
+
+            $meetingCounts[] = [
+                $meeting->getAbsentees()->count(),
+                [$meeting->getTitle(), "absentees"]
+            ];
+
+            $meetingCounts[] = [
+                $meeting->getQuorum(),
+                [$meeting->getTitle(), "quorum"]
+            ];
+        }
+
+        return $meetingCounts;
+    }
+}

--- a/app/Providers/PrometheusServiceProvider.php
+++ b/app/Providers/PrometheusServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use HMS\Prometheus\Collectors\Gatekeeper\DoorCollector;
+use HMS\Prometheus\Collectors\Governance\MeetingCollector;
 use HMS\Prometheus\Collectors\Instrumentation\BarometricPressureCollector;
 use HMS\Prometheus\Collectors\Instrumentation\HumidityCollector;
 use HMS\Prometheus\Collectors\Instrumentation\LightLevelCollector;
@@ -11,7 +12,6 @@ use HMS\Prometheus\Collectors\Instrumentation\SensorBatteryCollector;
 use HMS\Prometheus\Collectors\Instrumentation\ServiceCollector;
 use HMS\Prometheus\Collectors\Instrumentation\TemperatureCollector;
 use HMS\Prometheus\Collectors\SpaceOpenCollector;
-use HMS\Prometheus\Collectors\Governance\MeetingCollector;
 use HMS\Prometheus\Collectors\Statistics\BoxUsageCollector;
 use HMS\Prometheus\Collectors\Statistics\MembersshipStatisticsCollector;
 use HMS\Prometheus\Collectors\Statistics\ToolUsageCollector;

--- a/app/Providers/PrometheusServiceProvider.php
+++ b/app/Providers/PrometheusServiceProvider.php
@@ -11,6 +11,7 @@ use HMS\Prometheus\Collectors\Instrumentation\SensorBatteryCollector;
 use HMS\Prometheus\Collectors\Instrumentation\ServiceCollector;
 use HMS\Prometheus\Collectors\Instrumentation\TemperatureCollector;
 use HMS\Prometheus\Collectors\SpaceOpenCollector;
+use HMS\Prometheus\Collectors\Governance\MeetingCollector;
 use HMS\Prometheus\Collectors\Statistics\BoxUsageCollector;
 use HMS\Prometheus\Collectors\Statistics\MembersshipStatisticsCollector;
 use HMS\Prometheus\Collectors\Statistics\ToolUsageCollector;
@@ -79,6 +80,7 @@ class PrometheusServiceProvider extends ServiceProvider
     {
         Prometheus::registerCollectorClasses([
             BoxUsageCollector::class,
+            MeetingCollector::class,
             MembersshipStatisticsCollector::class,
             ToolUsageCollector::class,
         ]);


### PR DESCRIPTION
Thinking live dashboard in the hour running up to the meeting.

Might make sense to switch to `findNext()` instead of `paginateAll` but it would be nice to back fill previous AGMs. Happy to make a separate PR for that later if you like.

Also might generally be a bit database heavy since it's pulling User objects instead of counts? (edit: are collections lazy loaded?)