### PR TITLE
Set snackspace product max short_description lengthto 25

### DIFF
--- a/app/HMS/Mappings/HMS.Entities.Snackspace.Product.dcm.yml
+++ b/app/HMS/Mappings/HMS.Entities.Snackspace.Product.dcm.yml
@@ -22,6 +22,7 @@ HMS\Entities\Snackspace\Product:
       nullable: true
     shortDescription:
       type: string
+      length: 25
     longDescription:
       type: text
       nullable: true

--- a/app/Http/Controllers/Snackspace/ProductController.php
+++ b/app/Http/Controllers/Snackspace/ProductController.php
@@ -69,7 +69,7 @@ class ProductController extends Controller
     public function store(Request $request)
     {
         $validatedData = $request->validate([
-            'shortDescription' => 'required|string|max:255',
+            'shortDescription' => 'required|string|max:25',
             'longDescription' => 'sometimes|nullable|string',
             'barcode' => 'sometimes|nullable|string|max:255',
             'price' => 'required|integer|min:1',
@@ -129,7 +129,7 @@ class ProductController extends Controller
     public function update(Request $request, Product $product)
     {
         $validatedData = $request->validate([
-            'shortDescription' => 'required|string|max:255',
+            'shortDescription' => 'required|string|max:25',
             'longDescription' => 'sometimes|nullable|string',
             'barcode' => 'sometimes|nullable|string|max255',
             'price' => 'required|integer|min:1',

--- a/database/migrations_doctrine/Version20241120222758_alter_snackspace_short_description_max_length.php
+++ b/database/migrations_doctrine/Version20241120222758_alter_snackspace_short_description_max_length.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241120222758_alter_snackspace_short_description_max_length extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE products CHANGE short_description short_description VARCHAR(25) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE products CHANGE short_description short_description VARCHAR(255) NOT NULL');
+    }
+}


### PR DESCRIPTION
@daniel1111 identified the issue, here's a fix to hms

Issue with snackspace balance not being reduced for certain products is due to the short description being too long for a variable used in `sp_vend_success` 

https://github.com/NottingHack/database/blob/f2dcb2507aabd0530d80c9b056ac08dbe11fd347/procedures/sp_vend_success.sql#L25

This changes the validation length to 25 and restores the `short_description` field back to how it was before hms2

Descriptions have been adjusted in the production hms deployment to be a maximum of 25

Might want to go back and look for those recent vend failures - the product ids causing the issue were 342, 345 and 336. They have shorter names now.