### PR TITLE
Add variables to anonymous function scope for Trustee proxy notifications to Slack

### DIFF
--- a/app/Notifications/Governance/Proxy/NotifyTrusteesProxyCancelled.php
+++ b/app/Notifications/Governance/Proxy/NotifyTrusteesProxyCancelled.php
@@ -53,8 +53,7 @@ class NotifyTrusteesProxyCancelled extends Notification implements ShouldQueue
 
         return (new SlackMessage)
             ->to($notifiable->getSlackChannel())
-            ->attachment(fn ($attachment) =>
-                $attachment->title($this->meeting->getTitle() . ': Proxy Cancelled')
+            ->attachment(fn ($attachment) => $attachment->title($this->meeting->getTitle() . ': Proxy Cancelled')
                             ->content($content)
                             ->fallback($content)
                             ->timestamp(Carbon::now())

--- a/app/Notifications/Governance/Proxy/NotifyTrusteesProxyCancelled.php
+++ b/app/Notifications/Governance/Proxy/NotifyTrusteesProxyCancelled.php
@@ -53,11 +53,11 @@ class NotifyTrusteesProxyCancelled extends Notification implements ShouldQueue
 
         return (new SlackMessage)
             ->to($notifiable->getSlackChannel())
-            ->attachment(function ($attachment) {
+            ->attachment(fn ($attachment) =>
                 $attachment->title($this->meeting->getTitle() . ': Proxy Cancelled')
                             ->content($content)
                             ->fallback($content)
-                            ->timestamp(Carbon::now());
-            });
+                            ->timestamp(Carbon::now())
+            );
     }
 }

--- a/app/Notifications/Governance/Proxy/NotifyTrusteesProxyRegistered.php
+++ b/app/Notifications/Governance/Proxy/NotifyTrusteesProxyRegistered.php
@@ -55,8 +55,7 @@ class NotifyTrusteesProxyRegistered extends Notification implements ShouldQueue
 
         return (new SlackMessage)
             ->to($notifiable->getSlackChannel())
-            ->attachment(fn ($attachment) =>
-                $attachment->title($meeting->getTitle() . ': Proxy Registered')
+            ->attachment(fn ($attachment) => $attachment->title($meeting->getTitle() . ': Proxy Registered')
                             ->content($content)
                             ->fallback($content)
                             ->timestamp(Carbon::now())

--- a/app/Notifications/Governance/Proxy/NotifyTrusteesProxyRegistered.php
+++ b/app/Notifications/Governance/Proxy/NotifyTrusteesProxyRegistered.php
@@ -55,11 +55,11 @@ class NotifyTrusteesProxyRegistered extends Notification implements ShouldQueue
 
         return (new SlackMessage)
             ->to($notifiable->getSlackChannel())
-            ->attachment(function ($attachment) {
+            ->attachment(fn ($attachment) =>
                 $attachment->title($meeting->getTitle() . ': Proxy Registered')
                             ->content($content)
                             ->fallback($content)
-                            ->timestamp(Carbon::now());
-            });
+                            ->timestamp(Carbon::now())
+            );
     }
 }


### PR DESCRIPTION
I remembered seeing that there were notifications for this, but noticed we weren't getting any. Not tested, don't have a dev setup for Slack.