### PR TITLE
Slack stuff

### DIFF
--- a/app/HMS/Entities/Role.php
+++ b/app/HMS/Entities/Role.php
@@ -437,6 +437,10 @@ class Role implements RoleContract
      */
     public function routeNotificationForSlack(): false|string
     {
+        if (! config('hms.features.slack')) {
+            return false;
+        }
+
         if ($this->name == self::TEAM_TRUSTEES) {
             return config('hms.trustees_slack_webhook', false);
         } else {

--- a/app/Mail/Membership/MembershipComplete.php
+++ b/app/Mail/Membership/MembershipComplete.php
@@ -74,6 +74,11 @@ class MembershipComplete extends Mailable implements ShouldQueue
     /**
      * @var string
      */
+    public $discordHTML;
+
+    /**
+     * @var string
+     */
     public $wikiLink;
 
     /**
@@ -111,6 +116,7 @@ class MembershipComplete extends Mailable implements ShouldQueue
         $this->groupLink = $metaRepository->get('google_group_html');
         $this->rulesHTML = $metaRepository->get('rules_html');
         $this->slackHTML = $metaRepository->get('slack_html');
+        $this->discordHTML = $metaRepository->get('discord_html');
         $this->wikiLink = $metaRepository->get('wiki_html');
         $this->gatekeeperSetupGuide = $metaRepository->get('gatekeeper_setup_guide');
 

--- a/app/Mail/Membership/MembershipReinstated.php
+++ b/app/Mail/Membership/MembershipReinstated.php
@@ -68,6 +68,11 @@ class MembershipReinstated extends Mailable implements ShouldQueue
     /**
      * @var string
      */
+    public $discordHTML;
+
+    /**
+     * @var string
+     */
     public $wikiLink;
 
     /**
@@ -95,6 +100,7 @@ class MembershipReinstated extends Mailable implements ShouldQueue
         $this->groupLink = $metaRepository->get('google_group_html');
         $this->rulesHTML = $metaRepository->get('rules_html');
         $this->slackHTML = $metaRepository->get('slack_html');
+        $this->discordHTML = $metaRepository->get('discord_html');
         $this->wikiLink = $metaRepository->get('wiki_html');
 
         $this->membershipTeamEmail = $roleRepository->findOneByName(Role::TEAM_MEMBERSHIP)->getEmail();

--- a/config/hms.php
+++ b/config/hms.php
@@ -27,6 +27,7 @@ return [
         'space_api' => env('FEATURE_SPACEAPI', true),
         'mw_auth_hms' => env('FEATURE_MW_AUTH_WIKI', true),
         'slack' => env('FEATURE_SLACK', false),
+        'team_slack' => env('FEATURE_SLACK', false) && env('TEAM_SLACK_WEBHOOK', false),
         'discord' => env('FEATURE_DISCORD', false),
         'roundcube_login' => env('FEATURE_ROUNDCUBE_LOGIN', false) && env('ROUNDCUBE_LOGIN_HELPER_URL', false),
         'retention_email' => env('FEATURE_RETENTION_EMAIL', false),

--- a/config/meta.php
+++ b/config/meta.php
@@ -52,6 +52,7 @@ return [
         'self_book_max_length' => 180,
         'self_book_min_period_between_bookings' => 720,
         'slack_html' => 'http://slack.nottinghack.org.uk',
+        'discord_html' => 'http://wiki.nottinghack.org.uk/wiki/Discord',
         'so_bank_id' => 2,
         'temporary_access_email_link' => 'https://wiki.nottinghack.org.uk',
         'temporary_access_notification_delay' => 5,

--- a/config/meta.php
+++ b/config/meta.php
@@ -52,7 +52,7 @@ return [
         'self_book_max_length' => 180,
         'self_book_min_period_between_bookings' => 720,
         'slack_html' => 'http://slack.nottinghack.org.uk',
-        'discord_html' => 'http://wiki.nottinghack.org.uk/wiki/Discord',
+        'discord_html' => 'https://wiki.nottinghack.org.uk/wiki/Discord',
         'so_bank_id' => 2,
         'temporary_access_email_link' => 'https://wiki.nottinghack.org.uk',
         'temporary_access_notification_delay' => 5,

--- a/resources/views/emails/membership/membershipComplete.blade.php
+++ b/resources/views/emails/membership/membershipComplete.blade.php
@@ -19,7 +19,7 @@ Pass: {{ $wifiPass }}
 Our Google Group is where a lot of online discussion takes place:  
 {{ $groupLink }}  
 
-@feature('teams_slack')
+@feature('team_slack')
 Slack is also used for team discussions. You can join NH teams slack at:  
 {{ $slackHTML }}  
 @endfeature

--- a/resources/views/emails/membership/membershipComplete.blade.php
+++ b/resources/views/emails/membership/membershipComplete.blade.php
@@ -19,8 +19,14 @@ Pass: {{ $wifiPass }}
 Our Google Group is where a lot of online discussion takes place:  
 {{ $groupLink }}  
 
+@feature('teams_slack')
 Slack is also used for team discussions. You can join NH teams slack at:  
 {{ $slackHTML }}  
+@endfeature
+@feature('discord')
+Discord is also used for members to chat online. You can join the NH Discord at:  
+{{ $discordHTML }}  
+@endfeature
 
 The {{ config('branding.space_type') }} rules:  
 {{ $rulesHTML }}  

--- a/resources/views/emails/membership/membershipReinstated.blade.php
+++ b/resources/views/emails/membership/membershipReinstated.blade.php
@@ -15,7 +15,7 @@ Pass: {{ $wifiPass }}
 Our Google Group is where a lot of online discussion takes place:  
 {{ $groupLink }}  
 
-@feature('teams_slack')
+@feature('team_slack')
 Slack is also used for team discussions. You can join NH teams slack at:  
 {{ $slackHTML }}  
 @endfeature

--- a/resources/views/emails/membership/membershipReinstated.blade.php
+++ b/resources/views/emails/membership/membershipReinstated.blade.php
@@ -15,8 +15,14 @@ Pass: {{ $wifiPass }}
 Our Google Group is where a lot of online discussion takes place:  
 {{ $groupLink }}  
 
+@feature('teams_slack')
 Slack is also used for team discussions. You can join NH teams slack at:  
 {{ $slackHTML }}  
+@endfeature
+@feature('discord')
+Discord is also used for members to chat online. You can join the NH Discord at:  
+{{ $discordHTML }}  
+@endfeature
 
 The {{ config('branding.space_type') }} rules:  
 {{ $rulesHTML }}  

--- a/resources/views/governance/proxies/designate_link.blade.php
+++ b/resources/views/governance/proxies/designate_link.blade.php
@@ -27,7 +27,7 @@ Designate a Proxy for {{ $meeting->getTitle() }}
     <ol>
       <li>Find a fellow member going to the AGM.</li>
       <li>Ask them if they will be you Proxy.</li>
-      <li>Email, Slack or SMS them the link below. Hint click (<button type="button" class="btn btn-light btn-sm" onclick="copyToClipboard('#designate-link')"><i class="far fa-copy"></i></button>) to copy it to your clipboard.</li>
+      <li>Share the link below to your proxy. Hint click (<button type="button" class="btn btn-light btn-sm" onclick="copyToClipboard('#designate-link')"><i class="far fa-copy"></i></button>) to copy it to your clipboard.</li>
       <li>Once your Proxy follows the link and confirms their acceptance you will receive confirmation via email.</li>
     </ol>
   </p>

--- a/resources/views/team/index.blade.php
+++ b/resources/views/team/index.blade.php
@@ -18,7 +18,7 @@
 
       <div class="row text-muted">
         <div class="col-md-4">Email: {{ $team->getEmail() }}</div>
-        @feature('slack')
+        @feature('team_slack')
         <div class="col-md-4">Slack: {{ $team->getSlackChannel() }}</div>
         @endfeature
         @feature('discord')


### PR DESCRIPTION
This separates some of the trustee / team slack bits so that the team slack integration can be safely disabled (I think!) by leaving `TEAM_SLACK_WEBHOOK` environment variable unset. It also changes the wording of the membership complete / reinstated email to refer to Discord / Slack based on features.