### PR TITLE
Notification sensitivity

### DIFF
--- a/app/HMS/Entities/Role.php
+++ b/app/HMS/Entities/Role.php
@@ -479,14 +479,14 @@ class Role implements RoleContract
         // to just return the whatever is returned from the ORM.
         if ($notification instanceof NotificationSensitivityInterface) {
             switch ($notification->getDiscordSensitivity()) {
-            case NotificationSensitivityType::PRIVATE:
-                return $privateChannel;
+                case NotificationSensitivityType::PRIVATE:
+                    return $privateChannel;
 
-            case NotificationSensitivityType::PUBLIC:
-                return $publicChannel;
+                case NotificationSensitivityType::PUBLIC:
+                    return $publicChannel;
 
-            case NotificationSensitivityType::ANY:
-                break;
+                case NotificationSensitivityType::ANY:
+                    break;
             }
         }
 

--- a/app/HMS/Entities/Role.php
+++ b/app/HMS/Entities/Role.php
@@ -2,6 +2,8 @@
 
 namespace HMS\Entities;
 
+use App\Notifications\NotificationSensitivityInterface;
+use App\Notifications\NotificationSensitivityType;
 use Doctrine\Common\Collections\ArrayCollection;
 use HMS\Helpers\Discord;
 use HMS\Traits\Entities\SoftDeletable;
@@ -11,8 +13,6 @@ use LaravelDoctrine\ACL\Contracts\Permission;
 use LaravelDoctrine\ACL\Contracts\Role as RoleContract;
 use LaravelDoctrine\ACL\Permissions\HasPermissions;
 use LaravelDoctrine\ORM\Notifications\Notifiable;
-use App\Notifications\NotificationSensitivityInterface;
-use App\Notifications\NotificationSensitivityType;
 
 class Role implements RoleContract
 {
@@ -491,7 +491,6 @@ class Role implements RoleContract
         }
 
         return $privateChannel ? $privateChannel : $publicChannel;
-
     }
 
     /**

--- a/app/HMS/Helpers/Discord.php
+++ b/app/HMS/Helpers/Discord.php
@@ -192,7 +192,8 @@ class Discord
      *
      * @return array
      */
-    private function getChannels() {
+    private function getChannels()
+    {
         // Avoid hitting redis if already in used for this instance of Discord
         if ($this->channels) {
             return $this->channels;

--- a/app/HMS/Helpers/Discord.php
+++ b/app/HMS/Helpers/Discord.php
@@ -188,7 +188,7 @@ class Discord
     }
 
     /**
-     * Obtains an array of Discord channels
+     * Obtains an array of Discord channels.
      *
      * @return array
      */
@@ -199,7 +199,7 @@ class Discord
         }
 
         $this->channels = Cache::remember('discord.channels', 3600, fn () => $this->client->guild->getGuildChannels([
-            'guild.id' => $this->guildId
+            'guild.id' => $this->guildId,
         ]));
 
         return $this->channels;

--- a/app/HMS/Helpers/Discord.php
+++ b/app/HMS/Helpers/Discord.php
@@ -2,6 +2,7 @@
 
 namespace HMS\Helpers;
 
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use RestCord\DiscordClient;
 
@@ -187,6 +188,24 @@ class Discord
     }
 
     /**
+     * Obtains an array of Discord channels
+     *
+     * @return array
+     */
+    private function getChannels() {
+        // Avoid hitting redis if already in used for this instance of Discord
+        if ($this->channels) {
+            return $this->channels;
+        }
+
+        $this->channels = Cache::remember('discord.channels', 3600, fn () => $this->client->guild->getGuildChannels([
+            'guild.id' => $this->guildId
+        ]));
+
+        return $this->channels;
+    }
+
+    /**
      * Find a discord channel by name.
      *
      * @param string $channelName
@@ -195,13 +214,7 @@ class Discord
      */
     public function findChannelByName(string $channelName)
     {
-        if (! $this->channels) {
-            $this->channels = $this->client->guild->getGuildChannels([
-                'guild.id' => $this->guildId,
-            ]);
-        }
-
-        foreach ($this->channels as $channel) {
+        foreach ($this->getChannels() as $channel) {
             if ($channel['name'] == $channelName) {
                 return $channel;
             }

--- a/app/Notifications/Banking/AuditResult.php
+++ b/app/Notifications/Banking/AuditResult.php
@@ -214,7 +214,6 @@ class AuditResult extends Notification implements ShouldQueue, NotificationSensi
         return (new DiscordMessage())->embed($embed);
     }
 
-
     /**
      * Returns the sensitivity for notification routing to
      * Discord. e.g. whether it should go to the private or public

--- a/app/Notifications/Banking/AuditResult.php
+++ b/app/Notifications/Banking/AuditResult.php
@@ -2,6 +2,8 @@
 
 namespace App\Notifications\Banking;
 
+use App\Notifications\NotificationSensitivityInterface;
+use App\Notifications\NotificationSensitivityType;
 use Carbon\Carbon;
 use HMS\Entities\Role;
 use HMS\Entities\User;
@@ -14,10 +16,8 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\View;
 use NotificationChannels\Discord\DiscordChannel;
 use NotificationChannels\Discord\DiscordMessage;
-use App\Notifications\DiscordNotificationSensitivity;
-use App\Notifications\NotificationSensitivityType;
 
-class AuditResult extends Notification implements ShouldQueue, DiscordNotificationSensitivity
+class AuditResult extends Notification implements ShouldQueue, NotificationSensitivityInterface
 {
     use Queueable;
 

--- a/app/Notifications/Banking/AuditResult.php
+++ b/app/Notifications/Banking/AuditResult.php
@@ -14,8 +14,10 @@ use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\View;
 use NotificationChannels\Discord\DiscordChannel;
 use NotificationChannels\Discord\DiscordMessage;
+use App\Notifications\DiscordNotificationSensitivity;
+use App\Notifications\NotificationSensitivityType;
 
-class AuditResult extends Notification implements ShouldQueue
+class AuditResult extends Notification implements ShouldQueue, DiscordNotificationSensitivity
 {
     use Queueable;
 
@@ -210,5 +212,18 @@ class AuditResult extends Notification implements ShouldQueue
         ];
 
         return (new DiscordMessage())->embed($embed);
+    }
+
+
+    /**
+     * Returns the sensitivity for notification routing to
+     * Discord. e.g. whether it should go to the private or public
+     * team channel.
+     *
+     * @return string
+     */
+    public function getDiscordSensitivity()
+    {
+        return NotificationSensitivityType::PUBLIC;
     }
 }

--- a/app/Notifications/NewMemberApprovalNeeded.php
+++ b/app/Notifications/NewMemberApprovalNeeded.php
@@ -2,6 +2,8 @@
 
 namespace App\Notifications;
 
+use App\Notifications\NotificationSensitivityInterface;
+use App\Notifications\NotificationSensitivityType;
 use Carbon\Carbon;
 use HMS\Entities\User;
 use Illuminate\Bus\Queueable;
@@ -11,10 +13,8 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\Discord\DiscordChannel;
 use NotificationChannels\Discord\DiscordMessage;
-use App\Notifications\DiscordNotificationSensitivity;
-use App\Notifications\NotificationSensitivityType;
 
-class NewMemberApprovalNeeded extends Notification implements ShouldQueue, DiscordNotificationSensitivity
+class NewMemberApprovalNeeded extends Notification implements ShouldQueue, NotificationSensitivityInterface
 {
     use Queueable;
 

--- a/app/Notifications/NewMemberApprovalNeeded.php
+++ b/app/Notifications/NewMemberApprovalNeeded.php
@@ -11,8 +11,10 @@ use Illuminate\Notifications\Messages\SlackMessage;
 use Illuminate\Notifications\Notification;
 use NotificationChannels\Discord\DiscordChannel;
 use NotificationChannels\Discord\DiscordMessage;
+use App\Notifications\DiscordNotificationSensitivity;
+use App\Notifications\NotificationSensitivityType;
 
-class NewMemberApprovalNeeded extends Notification implements ShouldQueue
+class NewMemberApprovalNeeded extends Notification implements ShouldQueue, DiscordNotificationSensitivity
 {
     use Queueable;
 
@@ -153,5 +155,17 @@ class NewMemberApprovalNeeded extends Notification implements ShouldQueue
         EOF;
 
         return DiscordMessage::create($message);
+    }
+
+    /**
+     * Returns the sensitivity for notification routing to
+     * Discord. e.g. whether it should go to the private or public
+     * team channel.
+     *
+     * @return string
+     */
+    public function getDiscordSensitivity()
+    {
+        return NotificationSensitivityType::PRIVATE;
     }
 }

--- a/app/Notifications/NewMemberApprovalNeeded.php
+++ b/app/Notifications/NewMemberApprovalNeeded.php
@@ -2,8 +2,6 @@
 
 namespace App\Notifications;
 
-use App\Notifications\NotificationSensitivityInterface;
-use App\Notifications\NotificationSensitivityType;
 use Carbon\Carbon;
 use HMS\Entities\User;
 use Illuminate\Bus\Queueable;

--- a/app/Notifications/NotificationSensitivityInterface.php
+++ b/app/Notifications/NotificationSensitivityInterface.php
@@ -2,7 +2,8 @@
 
 namespace App\Notifications;
 
-interface NotificationSensitivityInterface {
+interface NotificationSensitivityInterface
+{
     /**
      * Returns the sensitivity for notification routing to
      * Discord. e.g. whether it should go to the private or public

--- a/app/Notifications/NotificationSensitivityInterface.php
+++ b/app/Notifications/NotificationSensitivityInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Notifications;
+
+interface NotificationSensitivityInterface {
+    /**
+     * Returns the sensitivity for notification routing to
+     * Discord. e.g. whether it should go to the private or public
+     * team channel.
+     *
+     * @return string
+     */
+    public function getDiscordSensitivity();
+}

--- a/app/Notifications/NotificationSensitivityType.php
+++ b/app/Notifications/NotificationSensitivityType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Notifications;
+
+abstract class NotificationSensitivityType
+{
+    public const ANY = "ANY";
+    public const PUBLIC = "PUBLIC";
+    public const PRIVATE = "PRIVATE";
+}

--- a/app/Notifications/NotificationSensitivityType.php
+++ b/app/Notifications/NotificationSensitivityType.php
@@ -4,7 +4,7 @@ namespace App\Notifications;
 
 abstract class NotificationSensitivityType
 {
-    public const ANY = "ANY";
-    public const PUBLIC = "PUBLIC";
-    public const PRIVATE = "PRIVATE";
+    public const ANY = 'ANY';
+    public const PUBLIC = 'PUBLIC';
+    public const PRIVATE = 'PRIVATE';
 }

--- a/app/Notifications/NotifyIncommingRoleEmail.php
+++ b/app/Notifications/NotifyIncommingRoleEmail.php
@@ -2,6 +2,8 @@
 
 namespace App\Notifications;
 
+use App\Notifications\NotificationSensitivityInterface;
+use App\Notifications\NotificationSensitivityType;
 use HMS\Entities\Role;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -9,7 +11,7 @@ use Illuminate\Notifications\Notification;
 use NotificationChannels\Discord\DiscordChannel;
 use NotificationChannels\Discord\DiscordMessage;
 
-class NotifyIncommingRoleEmail extends Notification implements ShouldQueue
+class NotifyIncommingRoleEmail extends Notification implements ShouldQueue, NotificationSensitivityInterface
 {
     use Queueable;
 
@@ -82,5 +84,17 @@ class NotifyIncommingRoleEmail extends Notification implements ShouldQueue
         ];
 
         return (new DiscordMessage())->embed($embed);
+    }
+
+    /**
+     * Returns the sensitivity for notification routing to
+     * Discord. e.g. whether it should go to the private or public
+     * team channel.
+     *
+     * @return string
+     */
+    public function getDiscordSensitivity()
+    {
+        return NotificationSensitivityType::PRIVATE;
     }
 }

--- a/app/Notifications/NotifyIncommingRoleEmail.php
+++ b/app/Notifications/NotifyIncommingRoleEmail.php
@@ -2,8 +2,6 @@
 
 namespace App\Notifications;
 
-use App\Notifications\NotificationSensitivityInterface;
-use App\Notifications\NotificationSensitivityType;
 use HMS\Entities\Role;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;


### PR DESCRIPTION
Adds a new interface to allow notification handle whether it should go to the member / team channel on Discord.

Membership `AuditResult` will become public so you can see it again.

Adds caching to channels in Discord helper.