### PR TITLE
Allow a tool's transaction type to be overridden

### DIFF
--- a/app/HMS/Entities/Snackspace/TransactionType.php
+++ b/app/HMS/Entities/Snackspace/TransactionType.php
@@ -20,6 +20,11 @@ abstract class TransactionType
     public const TOOL = 'TOOL';
 
     /*
+     * Heater usage.
+     */
+    public const HEAT = 'HEAT';
+
+    /*
      * Purchase of a members box.
      */
     public const MEMBER_BOX = 'BOX';
@@ -52,6 +57,7 @@ abstract class TransactionType
         self::MANUAL => 'Manual',
         self::TOOL => 'Tool',
         self::MEMBER_BOX => 'Box',
+        self::HEAT => 'Heat',
         self::CASH_PAYMENT => 'Cash Payment',
         self::ONLINE_PAYMENT => 'Online Payment',
         self::DD_PAYMENT => 'Direct Debit Payment',

--- a/app/HMS/Entities/Tools/Tool.php
+++ b/app/HMS/Entities/Tools/Tool.php
@@ -81,6 +81,11 @@ class Tool
     protected $hidden;
 
     /**
+     * @var string
+     */
+    protected $transactionTypeOverride;
+
+    /**
      * @var \Doctrine\Common\Collections\Collection|Booking[]
      */
     protected $bookings;
@@ -307,6 +312,26 @@ class Tool
     public function setHidden(bool $hidden)
     {
         $this->hidden = $hidden;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getTransactionTypeOverride()
+    {
+        return $this->transactionTypeOverride;
+    }
+
+    /**
+     * @param string $transactionTypeOverride
+     *
+     * @return self
+     */
+    public function setTransactionType($transactionTypeOverride)
+    {
+        $this->transactionTypeOverride = $transactionTypeOverride;
 
         return $this;
     }

--- a/app/HMS/Mappings/HMS.Entities.Tools.Tool.dcm.yml
+++ b/app/HMS/Mappings/HMS.Entities.Tools.Tool.dcm.yml
@@ -43,6 +43,11 @@ HMS\Entities\Tools\Tool:
       type: boolean
       options:
         default: 0
+    transactionTypeOverride:
+      column: transaction_type_override
+      type: string
+      length: 255
+      nullable: true
   oneToMany:
     bookings:
       targetEntity: \HMS\Entities\Tools\Booking

--- a/app/Http/Controllers/Snackspace/PurchasePaymentController.php
+++ b/app/Http/Controllers/Snackspace/PurchasePaymentController.php
@@ -66,6 +66,7 @@ class PurchasePaymentController extends Controller
         $forVendPurchases = Payment::whereBetween('transaction_datetime', [$startDate, $endDate])->sum('for_vend');
         $forToolPurchases = Payment::whereBetween('transaction_datetime', [$startDate, $endDate])->sum('for_tool');
         $forBoxPurchases = Payment::whereBetween('transaction_datetime', [$startDate, $endDate])->sum('for_box');
+        $forHeatPurchases = Payment::whereBetween('transaction_datetime', [$startDate, $endDate])->sum('for_heat');
         $forOtherPurchases = Payment::whereBetween('transaction_datetime', [$startDate, $endDate])->sum('for_other');
         // dump($forVendPurchases + $forToolPurchases + $forBoxPurchases + $forOtherPurchases);
 
@@ -81,6 +82,7 @@ class PurchasePaymentController extends Controller
                 'forVendPurchases' => $forVendPurchases,
                 'forToolPurchases' => $forToolPurchases,
                 'forBoxPurchases' => $forBoxPurchases,
+                'forHeatPurchases' => $forHeatPurchases,
                 'forOtherPurchases' => $forOtherPurchases,
             ]);
     }

--- a/database/migrations_doctrine/Version20241209032809_add_tools_transaction_type_override.php
+++ b/database/migrations_doctrine/Version20241209032809_add_tools_transaction_type_override.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241209032809_add_tools_transaction_type_override extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Adds transaction_type_override column to tools table';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE tools ADD transaction_type_override VARCHAR(255) DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE tools DROP transaction_type_override');
+    }
+}

--- a/resources/views/snackspace/purchasePayment/payment_report.blade.php
+++ b/resources/views/snackspace/purchasePayment/payment_report.blade.php
@@ -44,6 +44,10 @@
       <td>@money($forBoxPurchases, 'GBP')</td>
     </tr>
     <tr>
+      <th>For Heating:</th>
+      <td>@money($forHeatPurchases, 'GBP')</td>
+    </tr>
+    <tr>
       <th>For Other:</th>
       <td>@money($forOtherPurchases, 'GBP')</td>
     </tr>


### PR DESCRIPTION
This requires changes to the database nottinghack/database#12

If that one is merged I can update the submodule in this PR.

I've not added the ability to add the override from HMS since tools would need to be enabled from the database anyway, and it's something which could easily break stuff if set to an invalid value.

If you'd prefer it to be done a different way I'm happy to chat