### PR TITLE
Tool page improvements

### DIFF
--- a/resources/views/tools/tool/create.blade.php
+++ b/resources/views/tools/tool/create.blade.php
@@ -94,6 +94,13 @@
       @enderror
     </div>
 
+    <div class="form-group form-check">
+      <input id="hidden" class="form-check-input" type="checkbox" name="hidden">
+      <label class="form-check-label" for="hidden">
+        Should the tool be hidden from regular users?
+      </label>
+    </div>
+
     <button type="submit" class="btn btn-primary btn-block">Add Tool</button>
   </form>
 </div>

--- a/resources/views/tools/tool/index.blade.php
+++ b/resources/views/tools/tool/index.blade.php
@@ -42,6 +42,9 @@
             @endif
           </td>
           <td data-title="Status">
+            @if ($tool->isHidden())
+            <span style="color: #195905" title="This tool is hidden for general users."><i class="fa fa-eye-slash" aria-hidden="true"></i></span>
+            @endif
             {{ $tool->getStatusString() }}
             @if ($tool->getStatus() == \HMS\Entities\Tools\ToolState::DISABLED && ! is_null($tool->getStatusText()))
             <br>{{ $tool->getStatusText() }}

--- a/resources/views/tools/tool/index.blade.php
+++ b/resources/views/tools/tool/index.blade.php
@@ -17,6 +17,7 @@
         <tr>
           <th class="d-none d-md-table-cell">&nbsp;</th>
           <th>Tool</th>
+          <th>Inducted</th>
           <th>Status</th>
           <th class="d-none d-md-table-cell">Cost per hour</th>
           <th>Next booking</th>
@@ -29,6 +30,17 @@
         <tr>
           <td class="d-none d-md-table-cell" style="width:25px"><a href="{{ route('tools.bookings.index', $tool->getId()) }}"><span style="color: #195905"><i class="far fa-calendar-alt" aria-hidden="true"></i></span></a></td>
           <td data-title="Tool"><a href="{{ route('tools.bookings.index', $tool->getId()) }}"><span class="d-md-none" style="color: #195905"><i class="far fa-calendar-alt" aria-hidden="true"></i>&nbsp;</span>{{ $tool->getDisplayName() }}</a></td>
+          <td data-title="Inducted">
+            @if ($tool->isRestricted())
+            @can('tools.' . $tool->getPermissionName() . '.use')
+            <span style="color: #195905" title="You are inducted on this tool."><i class="far fa-check" aria-hidden="true"></i></span>
+            @else
+            <span style="color: #195905" title="Request an induction to use this tool."><i class="far fa-times-circle" aria-hidden="true"></i></span>
+            @endcan
+            @else
+            <span style="color: #195905" title="No induction required."><i class="far fa-circle"aria-hidden="true"></i></span>
+            @endif
+          </td>
           <td data-title="Status">
             {{ $tool->getStatusString() }}
             @if ($tool->getStatus() == \HMS\Entities\Tools\ToolState::DISABLED && ! is_null($tool->getStatusText()))


### PR DESCRIPTION
* Adds an icon column indicating induction status on the tool. We'd like to add the wood lathe so that it can be booked (it's been getting a lot of use past few months), and making it clearer that it is not an induction tool would be a good thing.
* Adds an icon to the status field if the tool is hidden. This will only be visible to those that see all the tools. Avoids having to go into the tool settings to check.
* Adds the hidden tool checkbox to the create page as this was missing in pr #596. Fixes #620.