### PR TITLE
ViMbAdmin: Fix undefined $role on userEmailChanged

### DIFF
--- a/app/Listeners/ViMbAdminSubscriber.php
+++ b/app/Listeners/ViMbAdminSubscriber.php
@@ -329,7 +329,7 @@ class ViMbAdminSubscriber implements ShouldQueue
                 continue;
             }
 
-            if (! $event->role->isEmailSyncForwarding()) {
+            if (! $role->isEmailSyncForwarding()) {
                 continue;
             }
 


### PR DESCRIPTION
Noticed while trying to figure out if there was an issue with password resets (more than likely just hotmail trashing our emails).

Not actually sure if correct I think it's right?