### PR TITLE
Remove mobile-only banner for space access left over from COVID rules

### DIFF
--- a/resources/views/gatekeeper/space_access.blade.php
+++ b/resources/views/gatekeeper/space_access.blade.php
@@ -3,6 +3,13 @@
 @section('pageTitle', 'Space Access')
 
 @section('content')
+@if ($building->getAccessState() == HMS\Entities\Gatekeeper\BuildingAccessState::SELF_BOOK || $building->getAccessState() == HMS\Entities\Gatekeeper\BuildingAccessState::REQUESTED_BOOK)
+<div class="container d-block d-md-none">
+  <div class="alert alert-info" role="alert">
+    Scroll down for access bookings.
+  </div>
+</div>
+@endif
 <div class="container">
   <div class="row">
     @if (Meta::get('access_street_door') || Meta::get('access_inner_door'))

--- a/resources/views/gatekeeper/space_access.blade.php
+++ b/resources/views/gatekeeper/space_access.blade.php
@@ -3,11 +3,6 @@
 @section('pageTitle', 'Space Access')
 
 @section('content')
-<div class="container d-block d-md-none">
-  <div class="alert alert-info" role="alert">
-    Scroll down for access bookings.
-  </div>
-</div>
 <div class="container">
   <div class="row">
     @if (Meta::get('access_street_door') || Meta::get('access_inner_door'))


### PR DESCRIPTION
Banner spotted by Steve last week. This commit just removes that section from the top of the Space Access page